### PR TITLE
Replace JuicyPixels dependency with a mimetype check

### DIFF
--- a/discord-haskell.cabal
+++ b/discord-haskell.cabal
@@ -100,7 +100,6 @@ library
                      , iso8601-time
                      , MonadRandom
                      , req
-                     , JuicyPixels
                      , safe-exceptions
                      , text
                      , time

--- a/src/Discord/Internal/Rest/User.hs
+++ b/src/Discord/Internal/Rest/User.hs
@@ -50,15 +50,19 @@ data UserRequest a where
 
   GetUserConnections   :: UserRequest [ConnectionObject]
 
--- | Formatted avatar data https://discord.com/developers/docs/resources/user#avatar-data
+-- | @AvatarImageParsed@ represents the base64 encoding of an avatar image with
+-- accepted mime type and accepted file size. The constructor is not exported.
+-- Initialisation should be done using the 'parseAvatarImage' smart constructor.
 data AvatarImageParsed = AvatarImageParsed T.Text
   deriving (Show, Read, Eq, Ord)
 
--- | @parseAvatarImage bs@ will attempt to convert the given image ByteString
--- to the base64 format expected by the Discord API. It may return Left with an
--- error reason if the image format could not be predetermined from the
--- opening few bytes. This function does /not/ validate the rest of the image,
+-- | @parseAvatarImage bs@ will attempt to convert the given image bytestring
+-- @bs@ to the base64 format expected by the Discord API. It may return Left
+-- with an error reason if the image format could not be predetermined from the
+-- opening magic bytes. This function does /not/ validate the rest of the image,
 -- and this is up to the library user to check themselves.
+--
+-- This function accepts all file types accepted by 'getMimeType'.
 parseAvatarImage :: B.ByteString -> Either T.Text AvatarImageParsed
 parseAvatarImage bs
   | Just mime <- getMimeType bs = Right (AvatarImageParsed ("data:" <> mime <> ";base64," <> TE.decodeUtf8 (B64.encode bs)))

--- a/src/Discord/Internal/Rest/User.hs
+++ b/src/Discord/Internal/Rest/User.hs
@@ -7,19 +7,17 @@
 -- | Provides actions for Channel API interactions
 module Discord.Internal.Rest.User
   ( UserRequest(..)
-  , parseCurrentUserAvatar
-  , CurrentUserAvatar
+  , parseAvatarImage
+  , AvatarImageParsed
   ) where
 
 
 import Data.Aeson
-import Codec.Picture
 import Network.HTTP.Req ((/:))
 import qualified Network.HTTP.Req as R
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Base64 as B64
 
 import Discord.Internal.Rest.Prelude
@@ -39,7 +37,7 @@ data UserRequest a where
   -- | Returns a 'User' for a given user ID
   GetUser              :: UserId -> UserRequest User
   -- | Modify user's username & avatar pic
-  ModifyCurrentUser    :: T.Text -> CurrentUserAvatar -> UserRequest User
+  ModifyCurrentUser    :: T.Text -> AvatarImageParsed -> UserRequest User
   -- | Returns a list of user 'Guild' objects the current user is a member of.
   --   Requires the guilds OAuth2 scope.
   GetCurrentUserGuilds :: UserRequest [PartialGuild]
@@ -53,16 +51,18 @@ data UserRequest a where
   GetUserConnections   :: UserRequest [ConnectionObject]
 
 -- | Formatted avatar data https://discord.com/developers/docs/resources/user#avatar-data
-data CurrentUserAvatar = CurrentUserAvatar T.Text
+data AvatarImageParsed = AvatarImageParsed T.Text
   deriving (Show, Read, Eq, Ord)
 
-parseCurrentUserAvatar :: B.ByteString -> Either T.Text CurrentUserAvatar
-parseCurrentUserAvatar bs =
-  case decodeImage bs of
-    Left e -> Left (T.pack e)
-    Right im -> Right $ CurrentUserAvatar $ "data:image/png;base64,"
-                <> TE.decodeUtf8 (B64.encode (BL.toStrict (encodePng (convertRGBA8 im))))
-
+-- | @parseAvatarImage bs@ will attempt to convert the given image ByteString
+-- to the base64 format expected by the Discord API. It may return Left with an
+-- error reason if the image format could not be predetermined from the
+-- opening few bytes. This function does /not/ validate the rest of the image,
+-- and this is up to the library user to check themselves.
+parseAvatarImage :: B.ByteString -> Either T.Text AvatarImageParsed
+parseAvatarImage bs
+  | Just mime <- getMimeType bs = Right (AvatarImageParsed ("data:" <> mime <> ";base64," <> TE.decodeUtf8 (B64.encode bs)))
+  | otherwise                   = Left "Unsupported image format provided"
 
 userMajorRoute :: UserRequest a -> String
 userMajorRoute c = case c of
@@ -84,7 +84,7 @@ userJsonRequest c = case c of
 
   (GetUser user) -> Get (users // user ) mempty
 
-  (ModifyCurrentUser name (CurrentUserAvatar im)) ->
+  (ModifyCurrentUser name (AvatarImageParsed im)) ->
       Patch (users /: "@me")  (pure (R.ReqBodyJson (object [ "username" .= name
                                                            , "avatar" .= im ]))) mempty
 

--- a/src/Discord/Internal/Types/Prelude.hs
+++ b/src/Discord/Internal/Types/Prelude.hs
@@ -184,7 +184,12 @@ toMaybeJSON = return . toJSON
 -- | @getMimeType bs@ returns a possible mimetype for the given bytestring,
 -- based on the first several bytes. It may return any of PNG/JPEG/GIF or WEBP
 -- mimetypes, or Nothing if none are matched.
--- Borrowed from discord.py's implementation.
+--
+-- /Borrowed from discord.py's implementation./
+--
+-- Although Discord's official documentation does not state WEBP as a supported
+-- format, it has been accepted for both emojis and user avatars no problem
+-- when tested manually.
 getMimeType :: B.ByteString -> Maybe T.Text
 getMimeType bs
   | B.take 8 bs == "\x89\x50\x4E\x47\x0D\x0A\x1A\x0A"

--- a/src/Discord/Internal/Types/Prelude.hs
+++ b/src/Discord/Internal/Types/Prelude.hs
@@ -181,6 +181,22 @@ toMaybeJSON :: (ToJSON a) => a -> Maybe Value
 toMaybeJSON = return . toJSON
 
 
+-- | @Base64Image mime data@ represents the base64 encoding of an image (as
+-- @data@), together with a tag of its mime type (@mime@).  The constructor is
+-- only for Internal use, and its public export is hidden in Discord.Types.
+--
+-- Public creation of this datatype should be done using the relevant smart
+-- constructors for Emoji, Sticker, or Avatar.
+data Base64Image a = Base64Image T.Text T.Text
+  deriving (Show, Read, Eq, Ord)
+
+-- | The ToJSON instance for Base64Image creates a string representation of the
+-- image's base-64 data, suited for using as JSON values.
+--
+-- The format is: @data:%MIME%;base64,%DATA%@.
+instance ToJSON (Base64Image a) where
+  toJSON (Base64Image mime im) = String $ "data:" <> mime <> ";base64," <> im
+
 -- | @getMimeType bs@ returns a possible mimetype for the given bytestring,
 -- based on the first few magic bytes. It may return any of PNG/JPEG/GIF or WEBP
 -- mimetypes, or Nothing if none are matched.

--- a/src/Discord/Internal/Types/Prelude.hs
+++ b/src/Discord/Internal/Types/Prelude.hs
@@ -182,19 +182,21 @@ toMaybeJSON = return . toJSON
 
 
 -- | @getMimeType bs@ returns a possible mimetype for the given bytestring,
--- based on the first several bytes. It may return any of PNG/JPEG/GIF or WEBP
+-- based on the first few magic bytes. It may return any of PNG/JPEG/GIF or WEBP
 -- mimetypes, or Nothing if none are matched.
 --
--- /Borrowed from discord.py's implementation./
+-- Reference: https://en.wikipedia.org/wiki/List_of_file_signatures
 --
 -- Although Discord's official documentation does not state WEBP as a supported
 -- format, it has been accepted for both emojis and user avatars no problem
 -- when tested manually.
+--
+-- /Inspired by discord.py's implementation./
 getMimeType :: B.ByteString -> Maybe T.Text
 getMimeType bs
   | B.take 8 bs == "\x89\x50\x4E\x47\x0D\x0A\x1A\x0A"
   = Just "image/png"
-  | B.take 3 bs == "\xff\xd8\xff" || B.take 3 (B.drop 6 bs) `elem` ["JFIF", "Exif"]
+  | B.take 3 bs == "\xff\xd8\xff" || B.take 4 (B.drop 6 bs) `elem` ["JFIF", "Exif"]
   = Just "image/jpeg"
   | B.take 6 bs == "\x47\x49\x46\x38\x37\x61" || B.take 6 bs == "\x47\x49\x46\x38\x39\x61"
   = Just "image/gif"

--- a/src/Discord/Types.hs
+++ b/src/Discord/Types.hs
@@ -8,6 +8,7 @@ import Discord.Internal.Types hiding
     , GatewayReceivable(..)
     , EventInternalParse(..)
     , InternalDiscordEnum(..)
+    , Base64Image(..)
 
     , colorToInternal
     , convertToRGB


### PR DESCRIPTION
## Summary

Warning: Sorry for the long post!

This is a slightly drastic pull request in that it removes JuicyPixels as a dependency completely, replacing the image decoding process with mime-type checking. This is less accurate but good enough as a heuristic, and is used by other libraries like discord.py. The removal of JuicyPixels is thought to reduce compilation time (unchecked). 

The PR also fixes the interface for these image-related endpoints, offering a consistent UI. I'd love some opinions on this!

## In Depth

### Current State

`discord-haskell` currently has three places where image processing happens:
- **When creating a new emoji:** The current code attempts to decode the entire image to check if it's of valid dimensions and format, then encode it as base64. This is through the `parseEmojiImage` smart constructor for `EmojiImageParsed`.
- **When creating a new sticker:** The current code does not do any decoding, and instead has a public ADT to construct for PNG, APNG, and LOTTIE filetypes. No validation occurs.
- **When modifying the current user's avatar:** The current code decodes the entire image, and converts it unconditionally to png before encoding it as base64. This is through the `parseCurrentUserAvatar` smart constructor for `CurrentUserAvatar`.

There are several problems with this:
- They are not consistent. All three should be fairly similar in logic, but the sticker processing has a completely different API.
- Implementation detail, but the sticker mime types for base64 are incorrect: APNG is image/png (not image/apng), and LOTTIE is a regular application/json (not image/lottie)
- Avatars don't need to be converted to PNG unconditionally, as Discord accepts other image types as well.
- Compiling the whole of JuicyPixels just for image decoding is quite wasteful

### The PR

This PR adds a `getMimeType :: B.ByteString -> Maybe T.Text` function in the Prelude, which uses the first few magic bytes to figure out if a file is PNG, JPEG, WEBP, or GIF.

Then, the PR makes the three image processing APIs consistent, using the smart constructor approach already used with emojis/avatars. These will check for file size constraints where specified by Discord, and for mime types, but **will not** decode the image. Invalid image dimensions or corrupt images will not be detected, and will be up to the user to check. This is documented in the Haddock comments.

This method is inspired heavily by [discord.py's method](https://github.com/Rapptz/discord.py/blob/69b4d9a4fae44bef5414c5846f6e0c4712c1fda5/discord/utils.py#L569) of checking images.

## API Changes

- The `StickerData` ADT is removed. It is replaced by a hidden ADT and the `parseStickerImage` smart constructor.
- `parseCurrentUserAvatar` is renamed to `parseAvatarImage` so that all image-related smart constructors are named as `parse***Image`.
- Image validation and dimension checking is now offloaded to the library user. `discord-haskell` will only perform superficial mime type checking.