### PR TITLE
Loosen version bounds for http-client, http-api-data, and req

### DIFF
--- a/discord-haskell.cabal
+++ b/discord-haskell.cabal
@@ -96,10 +96,10 @@ library
     containers >=0.6 && <0.7,
     data-default >=0.7 && <0.8,
     emoji ==0.1.*,
-    http-client >=0.6 && <0.7,
+    http-client >=0.6 && <0.8,
     iso8601-time >=0.1 && <0.2,
     MonadRandom >=0.5 && <0.6,
-    req >=3.9 && <3.10,
+    req >=3.9 && <3.13,
     safe-exceptions >=0.1 && <0.2,
     text >=1.2 && <1.3,
     time >=1.9 && <1.10,
@@ -108,4 +108,4 @@ library
     mtl >=2.2 && <2.3,
     unliftio >=0.2 && <0.3,
     scientific >=0.3 && <0.4,
-    http-api-data >=0.4 && <0.5
+    http-api-data >=0.4 && <0.6


### PR DESCRIPTION
This PR loosens the version bounds upwards, to allow a wider range of dependency versions to work with our package.

- `http-client`: Bugfixes and changes in parts we don't use. It's not *really* clear if they follow [PVP](https://pvp.haskell.org/), but going from past changelogs, I think it's fine to expect a major version jump if a future change will break compatibility for the functionality we use.
- `http-api-data`: Drops compatibility for GHC 7, and some changes in parsing. Doesn't affect what we use, and probably won't until at least the next major version.
- `req`: Adds new utility functions and instances, none of which affect our package.

Built and tested with the highest allowed versions for each dependency! 