### PR TITLE
fix typo I think

### DIFF
--- a/src/Discord/Internal/Types/ApplicationCommands.hs
+++ b/src/Discord/Internal/Types/ApplicationCommands.hs
@@ -126,7 +126,7 @@ instance FromJSON ApplicationCommand where
             _ -> do
               desc <- v .: "description"
               options <- v .:? "options"
-              ldesc <- v .: "description_localizations"
+              ldesc <- v .:? "description_localizations"
               return $ ApplicationCommandChatInput acid aid gid name lname desc ldesc options defPerm dmPerm version
       )
 


### PR DESCRIPTION
GetGlobalApplicationCommands was failing with
```
RestCallErrorCode 400 "Library Parse Exception" "restcall - parse exception [Error in $[0]: key \"description_localizations\" not found]
```
This fix worked for me locally. It seems like just a typo / forgetting the field is optional.