### PR TITLE
allow command names to have numbers

### DIFF
--- a/src/Discord/Internal/Types/ApplicationCommands.hs
+++ b/src/Discord/Internal/Types/ApplicationCommands.hs
@@ -36,7 +36,7 @@ import Data.Aeson.Types (Pair, Parser)
 import Data.Data (Data)
 import Data.Foldable (Foldable (toList))
 import Data.Scientific (Scientific)
-import           Data.Char (isLower)
+import           Data.Char (isLower, isNumber)
 import qualified Data.Text as T
 import Discord.Internal.Types.Prelude (ApplicationCommandId, ApplicationId, GuildId, InternalDiscordEnum (..), Snowflake, discordTypeParseJSON, objectFromMaybes, (.==), (.=?))
 import Data.Map.Strict (Map)
@@ -565,7 +565,7 @@ nameIsValid :: Bool -> T.Text -> Bool
 nameIsValid isChatInput name = l >= 1 && l <= 32 && isChatInput <= T.all validChar name
   where
     l = T.length name
-    validChar c = c == '-' || c == '_' || isLower c
+    validChar c = c == '-' || c == '_' || isLower c || isNumber c
 
 -- | Create the basics for a chat input (slash command). Use record overwriting
 -- to enter the other values. The name needs to be all lower case letters, and


### PR DESCRIPTION
Fixes https://github.com/discord-haskell/discord-haskell/issues/147 for real this time.

[Previous PR](https://github.com/discord-haskell/discord-haskell/pull/149) refactored the isValidName function, but didn't implement the fix for the issue: which is to allow numbers in the name.

