### PR TITLE
Expose Discord.Internal.Rest.ScheduledEvents

### DIFF
--- a/discord-haskell.cabal
+++ b/discord-haskell.cabal
@@ -128,6 +128,7 @@ library
     , Discord.Internal.Rest.Webhook
     , Discord.Internal.Rest.ApplicationCommands
     , Discord.Internal.Rest.Interactions
+    , Discord.Internal.Rest.ScheduledEvents
     , Discord.Internal.Types
     , Discord.Internal.Types.Prelude
     , Discord.Internal.Types.Channel

--- a/src/Discord/Requests.hs
+++ b/src/Discord/Requests.hs
@@ -8,6 +8,7 @@ module Discord.Requests
   , module Discord.Internal.Rest.Webhook
   , module Discord.Internal.Rest.ApplicationCommands
   , module Discord.Internal.Rest.Interactions
+  , module Discord.Internal.Rest.ScheduledEvents
   ) where
 
 import Discord.Internal.Rest.Channel
@@ -19,3 +20,4 @@ import Discord.Internal.Rest.Voice
 import Discord.Internal.Rest.Webhook
 import Discord.Internal.Rest.ApplicationCommands
 import Discord.Internal.Rest.Interactions
+import Discord.Internal.Rest.ScheduledEvents


### PR DESCRIPTION
Looks like this was implemented a while ago and the corresponding Types module was exposed, but not the Rest one.