### PR TITLE
Finished implementation of new Role Permissions

### DIFF
--- a/discord-haskell.cabal
+++ b/discord-haskell.cabal
@@ -154,6 +154,7 @@ library
     , Discord.Internal.Types.Components
     , Discord.Internal.Types.Color
     , Discord.Internal.Types.Emoji
+    , Discord.Internal.Types.RolePermissions
     , Discord.Internal.Types.ScheduledEvents
   build-depends:
   -- https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/libraries/version-history

--- a/src/Discord/Internal/Rest/Guild.hs
+++ b/src/Discord/Internal/Rest/Guild.hs
@@ -177,7 +177,7 @@ instance ToJSON CreateGuildBanOpts where
 -- | Options for `ModifyGuildRole`
 data ModifyGuildRoleOpts = ModifyGuildRoleOpts
   { modifyGuildRoleOptsName            :: Maybe T.Text
-  , modifyGuildRoleOptsPermissions     :: Maybe T.Text
+  , modifyGuildRoleOptsPermissions     :: Maybe RolePermissions
   , modifyGuildRoleOptsColor           :: Maybe DiscordColor
   , modifyGuildRoleOptsSeparateSidebar :: Maybe Bool
   , modifyGuildRoleOptsMentionable     :: Maybe Bool
@@ -186,7 +186,7 @@ data ModifyGuildRoleOpts = ModifyGuildRoleOpts
 instance ToJSON ModifyGuildRoleOpts where
   toJSON ModifyGuildRoleOpts{..} = objectFromMaybes
                        ["name" .=? modifyGuildRoleOptsName,
-                        "permissions" .=? modifyGuildRoleOptsPermissions,
+                        "permissions" .=? fmap (T.pack . show) modifyGuildRoleOptsPermissions,
                         "color" .=? modifyGuildRoleOptsColor,
                         "hoist" .=? modifyGuildRoleOptsSeparateSidebar,
                         "mentionable" .=? modifyGuildRoleOptsMentionable]

--- a/src/Discord/Internal/Rest/Guild.hs
+++ b/src/Discord/Internal/Rest/Guild.hs
@@ -186,7 +186,7 @@ data ModifyGuildRoleOpts = ModifyGuildRoleOpts
 instance ToJSON ModifyGuildRoleOpts where
   toJSON ModifyGuildRoleOpts{..} = objectFromMaybes
                        ["name" .=? modifyGuildRoleOptsName,
-                        "permissions" .=? fmap (T.pack . show) modifyGuildRoleOptsPermissions,
+                        "permissions" .=? modifyGuildRoleOptsPermissions,
                         "color" .=? modifyGuildRoleOptsColor,
                         "hoist" .=? modifyGuildRoleOptsSeparateSidebar,
                         "mentionable" .=? modifyGuildRoleOptsMentionable]

--- a/src/Discord/Internal/Types.hs
+++ b/src/Discord/Internal/Types.hs
@@ -10,6 +10,7 @@ module Discord.Internal.Types
     module Discord.Internal.Types.Embed,
     module Discord.Internal.Types.Components,
     module Discord.Internal.Types.Emoji,
+    module Discord.Internal.Types.RolePermissions,
     module Data.Aeson,
     module Data.Time.Clock,
     userFacingEvent,
@@ -28,6 +29,7 @@ import Discord.Internal.Types.Gateway
 import Discord.Internal.Types.Guild
 import Discord.Internal.Types.Prelude
 import Discord.Internal.Types.User
+import Discord.Internal.Types.RolePermissions
 
 -- | Converts an internal event to its user facing counterpart
 userFacingEvent :: EventInternalParse -> Event

--- a/src/Discord/Internal/Types/Guild.hs
+++ b/src/Discord/Internal/Types/Guild.hs
@@ -13,11 +13,9 @@ import Data.Default (Default(..))
 
 import Discord.Internal.Types.Prelude
 import Discord.Internal.Types.Color (DiscordColor)
-import Discord.Internal.Types.User (User, GuildMember (memberRoles))
+import Discord.Internal.Types.User (User)
 import Discord.Internal.Types.Emoji (Emoji, StickerItem)
-import Data.Bits
 import Data.List
-import Data.Maybe (fromMaybe)
 import Text.Read (readMaybe)
 
 -- | Guilds in Discord represent a collection of users and channels into an isolated
@@ -25,7 +23,7 @@ import Text.Read (readMaybe)
 --
 -- https://discord.com/developers/docs/resources/guild#guild-object
 data Guild = Guild
-      { guildId                   :: GuildId              -- ^ Gulid id
+      { guildId                   :: GuildId              -- ^ Guild id
       , guildName                 :: T.Text               -- ^ Guild name (2 - 100 chars)
       , guildIcon                 :: Maybe T.Text         -- ^ Icon hash
       , guildIconHash             :: Maybe T.Text         -- ^ Icon hash, when returned in template object
@@ -264,7 +262,7 @@ data Role =
       , roleColor   :: DiscordColor              -- ^ Integer representation of color code
       , roleHoist   :: Bool                      -- ^ If the role is pinned in the user listing
       , rolePos     :: Integer                   -- ^ Position of this role
-      , rolePerms   :: T.Text                    -- ^ Permission bit set
+      , rolePerms   :: RolePermissions           -- ^ Permission bit set
       , roleManaged :: Bool                      -- ^ Whether this role is managed by an integration
       , roleMention :: Bool                      -- ^ Whether this role is mentionable
     } deriving (Show, Read, Eq, Ord)
@@ -276,77 +274,15 @@ instance FromJSON Role where
          <*> o .: "color"
          <*> o .: "hoist"
          <*> o .: "position"
-         <*> o .: "permissions"
+         <*> fmap (readMaybe . T.unpack) (o .: "permissions") .!= RolePermissions 0
          <*> o .: "managed"
          <*> o .: "mentionable"
+
 
 -- | If there is no such role on the guild return nothing
 --   otherwise return the role. Take the head of the list. List should always be one, because the ID is unique
 roleIdToRole :: Guild -> RoleId -> Maybe Role
 roleIdToRole  g r = find(\x -> roleId x == r) $ guildRoles g
-
-data PermissionFlag =
-    CREATE_INSTANT_INVITE
-  | KICK_MEMBERS
-  | BAN_MEMBERS
-  | ADMINISTRATOR
-  | MANAGE_CHANNELS
-  | MANAGE_GUILD
-  | ADD_REACTIONS
-  | VIEW_AUDIT_LOG
-  | PRIORITY_SPEAKER
-  | STREAM
-  | VIEW_CHANNEL
-  | SEND_MESSAGES
-  | SEND_TTS_MESSAGES
-  | MANAGE_MESSAGES
-  | EMBED_LINKS
-  | ATTACH_FILES
-  | READ_MESSAGE_HISTORY
-  | MENTION_EVERYONE
-  | USE_EXTERNAL_EMOJIS
-  | VIEW_GUILD_INSIGHT
-  | CONNECT
-  | SPEAK
-  | MUTE_MEMBERS
-  | DEAFEN_MEMBERS
-  | MOVE_MEMBERS
-  | USE_VAD
-  | CHANGE_NICKNAME
-  | MANAGE_NICKNAMES
-  | MANAGE_ROLES
-  | MANAGE_WEBHOOKS
-  | MANAGE_EMOJIS_AND_STICKERS
-  | USE_APPLICATION_COMMANDS
-  | REQUEST_TO_SPEAK
-  | MANAGE_EVENTS
-  | MANAGE_THREADS
-  | CREATE_PUBLIC_THREADS
-  | CREATE_PRIVATE_THREADS
-  | USE_EXTERNAL_STICKERS
-  | SEND_MESSAGES_IN_THREADS
-  | USE_EMBEDDED_ACTIVITIES
-  deriving (Enum,Show)
-
-
--- | Check if a given role has the permission
---   RolePerms need to be an int to be converted into its bits
---   Bitwise & checks if rolePermission contains the perm
-hasRolePermission :: Maybe Int -> PermissionFlag -> Bool
-hasRolePermission r p = (.&.) (fromMaybe 0 r) (shift 1 $ fromEnum p) > 0
-
-
-
--- | Check if any Role of an GuildMember has the needed permission
---   If the result of roleIdToRole is Nothing, it appends an "False"
---   Otherwise it checks for the needed permission
-hasGuildMemberPermission :: Guild -> GuildMember -> PermissionFlag -> Bool
-hasGuildMemberPermission g gm p = or $ go (memberRoles gm)
-  where
-    go [] = []
-    go (x:xs)  = case roleIdToRole g x of
-                    Nothing ->  [False] <> go xs
-                    Just a ->  [readMaybe (T.unpack (rolePerms a)) `hasRolePermission` p] <> go xs
 
 
 -- | VoiceRegion is only refrenced in Guild endpoints, will be moved when voice support is added

--- a/src/Discord/Internal/Types/Guild.hs
+++ b/src/Discord/Internal/Types/Guild.hs
@@ -16,7 +16,6 @@ import Discord.Internal.Types.Color (DiscordColor)
 import Discord.Internal.Types.User (User)
 import Discord.Internal.Types.Emoji (Emoji, StickerItem)
 import Data.List
-import Text.Read (readMaybe)
 
 -- | Guilds in Discord represent a collection of users and channels into an isolated
 --   "Server"
@@ -274,7 +273,7 @@ instance FromJSON Role where
          <*> o .: "color"
          <*> o .: "hoist"
          <*> o .: "position"
-         <*> fmap (readMaybe . T.unpack) (o .: "permissions") .!= RolePermissions 0
+         <*> o .: "permissions"
          <*> o .: "managed"
          <*> o .: "mentionable"
 

--- a/src/Discord/Internal/Types/Prelude.hs
+++ b/src/Discord/Internal/Types/Prelude.hs
@@ -119,6 +119,12 @@ newtype RolePermissions = RolePermissions { getRolePermissions :: Integer }
 instance Read RolePermissions where
   readsPrec p = fmap (first RolePermissions) . readsPrec p
 
+instance ToJSON RolePermissions where
+  toJSON = toJSON . getRolePermissions
+
+instance FromJSON RolePermissions where
+  parseJSON = fmap RolePermissions . parseJSON
+
 instance Show RolePermissions where
   show = show . getRolePermissions
 

--- a/src/Discord/Internal/Types/Prelude.hs
+++ b/src/Discord/Internal/Types/Prelude.hs
@@ -13,6 +13,8 @@ module Discord.Internal.Types.Prelude
 
   , Snowflake (..)
   , snowflakeCreationDate
+
+  , RolePermissions (..)
   
   , DiscordId (..)
   , ChannelId
@@ -110,6 +112,15 @@ instance FromJSON Snowflake where
 
 instance ToHttpApiData Snowflake where
   toUrlPiece = T.pack . show
+
+newtype RolePermissions = RolePermissions { getRolePermissions :: Integer } 
+  deriving (Eq, Ord, Num, Bits, Enum, Real, Integral)
+
+instance Read RolePermissions where
+  readsPrec p = fmap (first RolePermissions) . readsPrec p
+
+instance Show RolePermissions where
+  show = show . getRolePermissions
 
 newtype DiscordId a = DiscordId { unId :: Snowflake }
   deriving (Ord, Eq, Num, Integral, Enum, Real, Bits)

--- a/src/Discord/Internal/Types/RolePermissions.hs
+++ b/src/Discord/Internal/Types/RolePermissions.hs
@@ -108,12 +108,12 @@ combinePermissions :: [PermissionFlag] -> RolePermissions
 combinePermissions = foldr ((.|.) . permissionBits) 0
 
 -- | Check if any Role of an GuildMember has the needed permission
---   If the result of roleIdToRole is Nothing, it appends an "False"
+--   If the result of roleIdToRole is Nothing, it prepends a "False"
 --   Otherwise it checks for the needed permission
 hasGuildMemberPermission :: Guild -> GuildMember -> PermissionFlag -> Bool
-hasGuildMemberPermission g gm p = or $ go (memberRoles gm)
+hasGuildMemberPermission g gm p = go (memberRoles gm)
   where
-    go [] = []
+    go [] = False
     go (x : xs) = case roleIdToRole g x of
-      Nothing -> [False] <> go xs
-      Just a -> [p `hasRolePermission` rolePerms a] <> go xs
+      Nothing -> go xs
+      Just a -> p `hasRolePermission` rolePerms a || go xs

--- a/src/Discord/Internal/Types/RolePermissions.hs
+++ b/src/Discord/Internal/Types/RolePermissions.hs
@@ -1,0 +1,119 @@
+module Discord.Internal.Types.RolePermissions
+  ( PermissionFlag (..),
+    hasRolePermissions,
+    hasRolePermission,
+    newRolePermissions,
+    newRolePermission,
+    setRolePermissions,
+    setRolePermission,
+    clearRolePermissions,
+    clearRolePermission,
+    hasGuildMemberPermission,
+  )
+where
+
+import Data.Bits (Bits (complement, shift, (.&.), (.|.)))
+import Discord.Internal.Types.Guild
+  ( Guild,
+    Role (rolePerms),
+    roleIdToRole,
+  )
+import Discord.Internal.Types.Prelude (RolePermissions)
+import Discord.Internal.Types.User (GuildMember (memberRoles))
+
+data PermissionFlag
+  = CREATE_INSTANT_INVITE
+  | KICK_MEMBERS
+  | BAN_MEMBERS
+  | ADMINISTRATOR
+  | MANAGE_CHANNELS
+  | MANAGE_GUILD
+  | ADD_REACTIONS
+  | VIEW_AUDIT_LOG
+  | PRIORITY_SPEAKER
+  | STREAM
+  | VIEW_CHANNEL
+  | SEND_MESSAGES
+  | SEND_TTS_MESSAGES
+  | MANAGE_MESSAGES
+  | EMBED_LINKS
+  | ATTACH_FILES
+  | READ_MESSAGE_HISTORY
+  | MENTION_EVERYONE
+  | USE_EXTERNAL_EMOJIS
+  | VIEW_GUILD_INSIGHT
+  | CONNECT
+  | SPEAK
+  | MUTE_MEMBERS
+  | DEAFEN_MEMBERS
+  | MOVE_MEMBERS
+  | USE_VAD
+  | CHANGE_NICKNAME
+  | MANAGE_NICKNAMES
+  | MANAGE_ROLES
+  | MANAGE_WEBHOOKS
+  | MANAGE_EMOJIS_AND_STICKERS
+  | USE_APPLICATION_COMMANDS
+  | REQUEST_TO_SPEAK
+  | MANAGE_EVENTS
+  | MANAGE_THREADS
+  | CREATE_PUBLIC_THREADS
+  | CREATE_PRIVATE_THREADS
+  | USE_EXTERNAL_STICKERS
+  | SEND_MESSAGES_IN_THREADS
+  | USE_EMBEDDED_ACTIVITIES
+  | MODERATE_MEMBERS
+  deriving (Eq, Ord, Enum, Show)
+
+permissionBits :: PermissionFlag -> RolePermissions
+permissionBits p = shift 1 (fromEnum p)
+
+-- | Check if a given role has all the permissions
+hasRolePermissions :: [PermissionFlag] -> RolePermissions -> Bool
+hasRolePermissions permissions rolePermissions = (.&.) combinedPermissions rolePermissions == combinedPermissions
+  where
+    combinedPermissions = combinePermissions permissions
+
+-- | Check if a given role has the permission
+hasRolePermission :: PermissionFlag -> RolePermissions -> Bool
+hasRolePermission p r = (.&.) (permissionBits p) r > 0
+
+-- | Replace a users rolePerms
+--   with a complete new set of permissions
+newRolePermissions :: [PermissionFlag] -> RolePermissions
+newRolePermissions = combinePermissions
+
+-- | Get the RolePermissions of a single PermissionFlag
+newRolePermission :: PermissionFlag -> RolePermissions
+newRolePermission = permissionBits
+
+-- | Update RolePermissions with new permissions
+setRolePermissions :: [PermissionFlag] -> RolePermissions -> RolePermissions
+setRolePermissions p r = combinePermissions p .|. r
+
+-- | Unset Permissions from RolePermissions
+clearRolePermissions :: [PermissionFlag] -> RolePermissions -> RolePermissions
+clearRolePermissions p r = (complement . combinePermissions) p .&. r
+
+-- | Set a certain permission flag
+--   This method doesn't lose the other already present permissions
+setRolePermission :: PermissionFlag -> RolePermissions -> RolePermissions
+setRolePermission p = (.|.) (permissionBits p)
+
+-- | Remove a permission from a user by clearing the bit
+clearRolePermission :: PermissionFlag -> RolePermissions -> RolePermissions
+clearRolePermission p = (.&.) (complement . permissionBits $ p)
+
+combinePermissions :: [PermissionFlag] -> RolePermissions
+combinePermissions = foldr ((.|.) . permissionBits) 0
+
+-- | Check if any Role of an GuildMember has the needed permission
+--   If the result of roleIdToRole is Nothing, it appends an "False"
+--   Otherwise it checks for the needed permission
+hasGuildMemberPermission :: Guild -> GuildMember -> PermissionFlag -> Bool
+hasGuildMemberPermission g gm p = or $ go (memberRoles gm)
+  where
+    go [] = []
+    go (x : xs) = case roleIdToRole g x of
+      Nothing -> [False] <> go xs
+      Just a -> [p `hasRolePermission` rolePerms a] <> go xs


### PR DESCRIPTION
As described in Issue #163 I've implemented a new RolePermissions system that expanded the previous one present in Guild.hs. Added as an internal type to Types and then exported forwards so taht it's available when importing Discord.Types. New representation of RolePermissions through a newtype that wraps around an Integer. The other functions are all bit operations mostly.