### PR TITLE
Fix parsing of role permissions

### DIFF
--- a/src/Discord/Internal/Types/Prelude.hs
+++ b/src/Discord/Internal/Types/Prelude.hs
@@ -122,8 +122,13 @@ instance Read RolePermissions where
 instance ToJSON RolePermissions where
   toJSON = toJSON . getRolePermissions
 
+-- In v8 and above, all permissions are serialized as strings.
+-- See https://discord.com/developers/docs/topics/permissions#permissions.
 instance FromJSON RolePermissions where
-  parseJSON = fmap RolePermissions . parseJSON
+  parseJSON = withText "RolePermissions" $
+      \text -> case readMaybe (T.unpack text) of
+              Just perms -> pure $ RolePermissions perms
+              Nothing    -> fail "invalid role permissions integer string"
 
 instance Show RolePermissions where
   show = show . getRolePermissions


### PR DESCRIPTION
Parsing of role permissions currently fails due (see #167) as the `FromJSON` instance expects a number despite [the API representing it as a string](https://discord.com/developers/docs/topics/permissions#permissions).

This fixes this error by parsing the string and attempting to read it as an integer, failing the parse otherwise.

According to the API docs [all permissions are serialized as strings from v8 onwards](https://discord.com/developers/docs/topics/permissions#permissions), but I'm not familiar enough with the Discord API to know if there are any other cases where it's still returned as a number. If those cases exist, a solution to handle both might be:
```haskell
instance FromJSON RolePermissions where
  parseJSON = fmap RolePermissions . parseJSON
  parseJSON v = (fmap RolePermissions . parseJSON $ v) <|> (withText "RolePermissions" $
      \text -> case readMaybe (T.unpack text) of
              Just perms -> pure $ RolePermissions perms
              Nothing    -> fail "invalid role permissions integer string") v
```
but I doubt its necessity at the moment.

---

Fixes #167.