### PR TITLE
add role icon to ModifyGuildRoleOpts

### DIFF
--- a/src/Discord/Internal/Rest/Guild.hs
+++ b/src/Discord/Internal/Rest/Guild.hs
@@ -181,6 +181,7 @@ data ModifyGuildRoleOpts = ModifyGuildRoleOpts
   , modifyGuildRoleOptsColor           :: Maybe DiscordColor
   , modifyGuildRoleOptsSeparateSidebar :: Maybe Bool
   , modifyGuildRoleOptsMentionable     :: Maybe Bool
+  , modifyGuildRoleOptsIcon            :: Maybe T.Text
   } deriving (Show, Read, Eq, Ord)
 
 instance ToJSON ModifyGuildRoleOpts where
@@ -189,7 +190,8 @@ instance ToJSON ModifyGuildRoleOpts where
                         "permissions" .=? modifyGuildRoleOptsPermissions,
                         "color" .=? modifyGuildRoleOptsColor,
                         "hoist" .=? modifyGuildRoleOptsSeparateSidebar,
-                        "mentionable" .=? modifyGuildRoleOptsMentionable]
+                        "mentionable" .=? modifyGuildRoleOptsMentionable,
+                        "icon" .=? modifyGuildRoleOptsIcon]
 
 -- | Options for `AddGuildMember`
 data AddGuildMemberOpts = AddGuildMemberOpts


### PR DESCRIPTION
Add ability to set/modify the role icon for guilds in which the required boost level is reached, by sending the image data encoded in base64. Affects the `CreateGuildRole` and `ModifyGuildRole` calls.

---

Example usage:

```haskell
restCall $ ModifyGuildRole guildId roleId $ ModifyGuildRoleOpts
    { modifyGuildRoleOptsName = Nothing
    , modifyGuildRoleOptsPermissions = Nothing
    , modifyGuildRoleOptsColor = Nothing
    , modifyGuildRoleOptsMentionable = Nothing
    , modifyGuildRoleOptsSeparateSidebar = Nothing
    , modifyGuildRoleOptsIcon = Just "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAABhWlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV/Tih9UROwg4hChioNdVMSxVqEIFUKt0KqDyaVf0KQhaXFxFFwLDn4sVh1cnHV1cBUEwQ8QVxcnRRcp8X9JoUWMB8f9eHfvcfcOEOolplmBKKDpFTMZj4npzKrY+YoA+tGNEYzLzDLmJCkBz/F1Dx9f7yI8y/vcn6NXzVoM8InEUWaYFeIN4pnNisF5nzjECrJKfE48YdIFiR+5rrj8xjnvsMAzQ2YqOU8cIhbzbay0MSuYGvE0cVjVdMoX0i6rnLc4a6Uqa96TvzCY1VeWuU5zGHEsYgkSRCiooogSKojQqpNiIUn7MQ//kOOXyKWQqwhGjgWUoUF2/OB/8LtbKzc16SYFY0DHi21/jAKdu0CjZtvfx7bdOAH8z8CV3vKX68DsJ+m1lhY+Avq2gYvrlqbsAZc7wOCTIZuyI/lpCrkc8H5G35QBBm6BnjW3t+Y+Th+AFHWVuAEODoGxPGWve7y7q723f880+/sBnFtyt90D698AAAAJcEhZcwAALiMAAC4jAXilP3YAAAAHdElNRQfnBBEJITEIIDn2AAAAGXRFWHRDb21tZW50AENyZWF0ZWQgd2l0aCBHSU1QV4EOFwAAABZJREFUCNdj/P//PwMDAxMDAwMDAwMAJAYDAb0e47oAAAAASUVORK5CYII="
    }
```
This example sets the role icon to a 2x2 white square.