### PR TITLE
Extend emoji support

### DIFF
--- a/discord-haskell.cabal
+++ b/discord-haskell.cabal
@@ -166,7 +166,7 @@ library
     base64-bytestring >=1.1 && <1.3,
     containers >=0.6 && <0.7,
     data-default >=0.7 && <0.8,
-    emojis >=0.1.2,
+    emojis >=0.1.2 && <0.2,
     http-client >=0.6 && <0.8,
     iso8601-time >=0.1 && <0.2,
     MonadRandom >=0.5 && <0.6,

--- a/discord-haskell.cabal
+++ b/discord-haskell.cabal
@@ -166,7 +166,7 @@ library
     base64-bytestring >=1.1 && <1.3,
     containers >=0.6 && <0.7,
     data-default >=0.7 && <0.8,
-    emoji ==0.1.*,
+    emojis >=0.1.2,
     http-client >=0.6 && <0.8,
     iso8601-time >=0.1 && <0.2,
     MonadRandom >=0.5 && <0.6,

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,9 +4,6 @@ packages:
 
 resolver: lts-18.28
 
-extra-deps:
-- emoji-0.1.0.2@sha256:d995572a5c7dcd28f98eb15c6e387a7b3bda1ac2477ab0d9dba8580d5d7b161f,1273
-
 
 nix:
   packages: [ zlib, gmp ]


### PR DESCRIPTION
This PR does two things:

1. switches to the `emojis` package instead of `emoji`, as described in #178
   
   Contrary to what I wrote in there, the `emojis` package doesn't actually contain every emoji that Discord has. For example, `:heart_hands:` is still missing. It's still a strict improvement over the previous version, though; and I'm going to put in an upstream PR to `emojis` later to update their list.

2. implements an inner function to apply the [skin tone modifiers](https://emojipedia.org/emoji-modifier-sequence/) `\x1f3fb` through `\x1f3ff`.
   
   Thus for example, `:+1:` is parsed into `\x1f44d` 👍, and `:+1_tone2:` is parsed into `\1f44d\x1f3fc` 👍🏼.
   
   (I *think* `discord-haskell` is the right place to implement this, rather than upstream, because different platforms use different strings for the skin tone modifiers. For example, Slack uses `:+1::skin-tone-2:` to denote the same emoji.)

---

Tested locally:

```haskell
{-# LANGUAGE OverloadedStrings #-}

module Main where

import Control.Monad.IO.Class (liftIO)
import qualified Data.Text as T
import Discord
import qualified Discord.Requests as DR
import Discord.Types
import System.Environment (getEnv)

main :: IO ()
main = do
  discordToken <- T.pack <$> getEnv "DISCORD_TOKEN"
  _ <- runDiscord $
      def
        { discordToken = discordToken,
          discordOnEvent = eventHandler,
          discordOnStart = pure ()
        }
  pure ()

eventHandler :: Event -> DiscordHandler ()
eventHandler event = case event of
  MessageCreate m -> do
    mapM_ (restCall . DR.CreateReaction (messageChannelId m, messageId m))
      [ ":heart:", ":blue_heart:", ":orange_heart:", ":brown_heart:", ":green_heart:"
      , ":+1:", ":+1_tone1:", ":+1_tone2:", ":+1_tone3:", ":+1_tone4:", ":+1_tone5:"]
  _ -> pure ()
```

Result:

<img width="620" alt="Screenshot 2023-07-21 at 23 12 11" src="https://github.com/discord-haskell/discord-haskell/assets/122629585/3f614aec-236b-410a-8530-3446133e5e9d">

