### PR TITLE
Bump emojis dependency to 0.1.3

### DIFF
--- a/discord-haskell.cabal
+++ b/discord-haskell.cabal
@@ -167,7 +167,7 @@ library
     base64-bytestring >=1.1 && <1.3,
     containers >=0.6 && <0.7,
     data-default >=0.7 && <0.8,
-    emojis >=0.1.2 && <0.2,
+    emojis >=0.1.3 && <0.2,
     http-client >=0.6 && <0.8,
     iso8601-time >=0.1 && <0.2,
     MonadRandom >=0.5 && <0.7,

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,8 @@ packages:
 
 resolver: lts-18.28
 
+extra-deps:
+  - emojis-0.1.3
 
 nix:
   packages: [ zlib, gmp ]


### PR DESCRIPTION
Hi, just a quick follow-up on #179 — my upstream PR to `emojis` got merged (https://github.com/jgm/emojis/pull/3), so bumping the dependency version here will give us access to the full set of emoji that Discord supports :)