### PR TITLE
Cache erroring

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,7 +1,5 @@
 ### Cache
 
-The cache (`readCache`) is currently deprecated.
-
-It's capable of working, but the code to update is not written.
+The cache (`readCache`) is currently a bit odd at times.
 
 Current source code is at [Discord.Internal.Gateway.Cache](../src/Discord/Internal/Gateway/Cache.hs)

--- a/examples/cache.hs
+++ b/examples/cache.hs
@@ -1,8 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
 
 import UnliftIO (liftIO)
 
 import Discord
+import Discord.Types
+
+import qualified Data.Text as T
 
 import ExampleUtils (getToken)
 
@@ -12,16 +16,20 @@ main = cacheExample
 -- There's not much information in the Cache for now
 --   but this program will show you what its got
 
+-- Note that the cache has to be enabled, and that this program will only print 
+-- out when a message is received.
+
 -- | Print cached Gateway info
 cacheExample :: IO ()
 cacheExample = do
   tok <- getToken
 
-  _ <- runDiscord $ def { discordToken = tok
-                        , discordOnStart = do
-                               cache <- readCache
-                               liftIO $ putStrLn ("Cached info from gateway: " <> show cache)
-                               stopDiscord
+  t <- runDiscord $ def { discordToken = tok
+                        , discordOnLog = putStrLn . T.unpack
+                        , discordOnEvent = \case
+                            MessageCreate _ -> readCache >>= liftIO . putStrLn . ("Current info as of new message: " <>) . show
+                            _ -> pure ()
+                        , discordEnableCache = True
                         }
-  pure ()
+  print t
 

--- a/src/Discord.hs
+++ b/src/Discord.hs
@@ -96,7 +96,7 @@ runDiscord opts = do
   events <- newChan :: IO EventChannel
   (cache, mCacheId) <- liftIO $ startCacheThread (discordEnableCache opts) log events
   (rest, restId) <- liftIO $ startRestThread (Auth (discordToken opts)) log
-  (gate, gateId) <- liftIO $ startGatewayThread (Auth (discordToken opts)) (discordGatewayIntent opts) cache log
+  (gate, gateId) <- liftIO $ startGatewayThread (Auth (discordToken opts)) (discordGatewayIntent opts) events log
 
   libE <- newEmptyMVar
 

--- a/src/Discord.hs
+++ b/src/Discord.hs
@@ -214,8 +214,8 @@ getCacheReference = do
   h <- ask
   cacheStatus <- readTVarIO (cacheHandleCache (discordHandleCache h))
   pure $ case cacheStatus of
-    CacheDisabled -> Left "cache enabled but waiting for ready event"
-    CacheWaiting -> Left "cache not enabled"
+    CacheDisabled -> Left "cache not enabled"
+    CacheWaiting -> Left "cache enabled but waiting for ready event"
     CacheReady c -> Right $ readTVarIO c
 
 -- | Stop all the background threads

--- a/src/Discord/Internal/Gateway.hs
+++ b/src/Discord/Internal/Gateway.hs
@@ -22,13 +22,15 @@ import Data.Time (getCurrentTime)
 
 import Discord.Internal.Types (Auth, EventInternalParse, GatewayIntent)
 import Discord.Internal.Gateway.EventLoop (connectionLoop, GatewayHandle(..), GatewayException(..), EventChannel)
-import Discord.Internal.Gateway.Cache (cacheLoop, Cache(..), CacheHandle(..))
+import Discord.Internal.Gateway.Cache (cacheLoop, Cache(..), CacheHandle(..), CacheStatus (CacheDisabled))
 
--- | Starts a thread for the cache
+-- | Starts a thread for the cache.
+--
+-- Only does so if the boolean is True.
 startCacheThread :: Bool -> Chan T.Text -> Chan (Either GatewayException EventInternalParse) -> IO (CacheHandle, Maybe ThreadId)
 startCacheThread isEnabled log events = do
   events' <- dupChan events
-  cache <- newTVarIO (error "discord-haskell: cache has not been enabled or initialised after a Ready event")
+  cache <- newTVarIO CacheDisabled
   let cacheHandle = CacheHandle cache
   mTid <- if isEnabled
     then fmap Just $ forkIO $ cacheLoop cacheHandle events' log

--- a/src/Discord/Internal/Gateway/EventLoop.hs
+++ b/src/Discord/Internal/Gateway/EventLoop.hs
@@ -163,12 +163,13 @@ connectionLoop auth intent gatewayHandle log = outerloop LoopStart
                                 threadDelay (3 * (10^(6 :: Int)))
                                 pure LoopStart
 
+type EventChannel = Chan (Either GatewayException EventInternalParse)
 
 -- | Process events from discord and write them to the onDiscordEvent Channel
 runEventLoop :: GatewayHandle -> SendablesData -> Chan T.Text -> IO LoopState
 runEventLoop thehandle sendablesData log = do loop
   where
-  eventChan :: Chan (Either GatewayException EventInternalParse)
+  eventChan :: EventChannel
   eventChan = gatewayHandleEvents thehandle
 
   -- | Keep receiving Dispatch events until a reconnect or a restart


### PR DESCRIPTION
Make the cache slightly more explicit in its two failure states so that users are less likely to get confused why they can't access it.