### PR TITLE
Change ReactionTiming type to match Discord docs

### DIFF
--- a/src/Discord/Internal/Rest/Channel.hs
+++ b/src/Discord/Internal/Rest/Channel.hs
@@ -159,16 +159,14 @@ instance Default MessageDetailedOpts where
                             }
 
 -- | Data constructor for `GetReactions` requests
-data ReactionTiming = BeforeReaction MessageId
-                    | AfterReaction MessageId
-                    | LatestReaction
+data ReactionTiming = AfterUser UserId
+                    | FirstUsers
   deriving (Show, Read, Eq, Ord)
 
 reactionTimingToQuery :: ReactionTiming -> R.Option 'R.Https
 reactionTimingToQuery t = case t of
-  (BeforeReaction snow) -> "before" R.=: show snow
-  (AfterReaction snow) -> "after"  R.=: show snow
-  LatestReaction -> mempty
+  (AfterUser snow) -> "after"  R.=: show snow
+  FirstUsers -> mempty
 
 -- | Data constructor for `GetChannelMessages` requests.
 -- 


### PR DESCRIPTION
Hi 🙂  Couple of fixes to the `ReactionTiming` type

- It takes a `UserId`, not a `MessageId` (cf. https://discord.com/developers/docs/resources/channel#get-reactions).
- The endpoint doesn't take a `before` query parameter so I removed that.
- After some experimentation, I think that omitting the `after` query parameter doesn't actually give the latest batch of reactions. It gives the first batch of reactions, which are ordered by user ID -- so effectively it fetches the reactions of the oldest users. I changed the constructor names to reflect this.