### PR TITLE
make Snowflake type derive num

### DIFF
--- a/src/Discord/Internal/Types/Prelude.hs
+++ b/src/Discord/Internal/Types/Prelude.hs
@@ -85,7 +85,7 @@ authToken (Auth tok) = let token = T.strip tok
 
 -- | A unique integer identifier. Can be used to calculate the creation date of an entity.
 newtype Snowflake = Snowflake { unSnowflake :: Word64 }
-  deriving (Ord, Eq)
+  deriving (Ord, Eq, Num)
 
 instance Show Snowflake where
   show (Snowflake a) = show a


### PR DESCRIPTION
Small change to allow int literals to be casted to Num.

Changes `DiscordId (Snowflake 11111)` to `DiscordId 111111`

