### PR TITLE
Add `Default` Instance for `InteractionResponseMessage`

### DIFF
--- a/src/Discord/Internal/Types/Embed.hs
+++ b/src/Discord/Internal/Types/Embed.hs
@@ -56,6 +56,8 @@ createEmbed CreateEmbed{..} =
            , embedProvider    = Nothing
            }
 
+-- | The 'Default' instance of this type yields a 'def' value whose fields are all empty.
+-- As such, the 'def' value is not a valid embed and needs to be adjusted before being used.
 data CreateEmbed = CreateEmbed
   { createEmbedAuthorName  :: T.Text
   , createEmbedAuthorUrl   :: T.Text

--- a/src/Discord/Internal/Types/Interactions.hs
+++ b/src/Discord/Internal/Types/Interactions.hs
@@ -604,6 +604,8 @@ instance ToJSON InteractionResponseAutocomplete where
   toJSON (InteractionResponseAutocompleteNumber cs) = object [("choices", toJSON cs)]
 
 -- | A cut down message structure.
+-- The 'Default' instance of this type yields a 'def' value whose fields are all empty.
+-- As such, the 'def' value is not a valid response message and needs to be adjusted before being used.
 data InteractionResponseMessage = InteractionResponseMessage
   { interactionResponseMessageTTS :: Maybe Bool,
     interactionResponseMessageContent :: Maybe T.Text,

--- a/src/Discord/Internal/Types/Interactions.hs
+++ b/src/Discord/Internal/Types/Interactions.hs
@@ -32,6 +32,7 @@ where
 
 import Control.Applicative (Alternative ((<|>)))
 import Control.Monad (join)
+import Data.Default
 import Data.Aeson
 import Data.Aeson.Types (Parser)
 import Data.Bits (Bits (shift, (.|.)))
@@ -618,6 +619,9 @@ data InteractionResponseMessage = InteractionResponseMessage
 -- effectively a helper function.
 interactionResponseMessageBasic :: T.Text -> InteractionResponseMessage
 interactionResponseMessageBasic t = InteractionResponseMessage Nothing (Just t) Nothing Nothing Nothing Nothing Nothing
+
+instance Default InteractionResponseMessage where
+  def = InteractionResponseMessage Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 instance ToJSON InteractionResponseMessage where
   toJSON InteractionResponseMessage {..} =


### PR DESCRIPTION
The type `InteractionResponseMessage` consists entirely of `Maybe` fields, so it works well with `Default`. This makes creating new response messages easier.