### PR TITLE
Add more fields to Fullapplication

### DIFF
--- a/src/Discord/Internal/Types/ApplicationInfo.hs
+++ b/src/Discord/Internal/Types/ApplicationInfo.hs
@@ -9,23 +9,64 @@ import qualified Data.Text as T
 import Discord.Internal.Types.Prelude
 
 -- | Structure containing partial information about an Application
+--    <https://discord.com/developers/docs/resources/application#application-object>
 data FullApplication = FullApplication
   { fullApplicationID :: ApplicationId
   , fullApplicationName :: T.Text
   , fullApplicationIcon :: Maybe T.Text -- ^ Icon hash
-  , fullApplicationDescription :: Maybe T.Text
-  , fullApplicationRPCOrigins :: [T.Text] -- ^ List of RPC origin URLs, if RPC is enabled
+  , fullApplicationDescription :: T.Text
+  , fullApplicationRPCOrigins :: Maybe [T.Text] -- ^ List of RPC origin URLs, if RPC is enabled
   , fullApplicationBotPublic :: Bool -- ^ When false, only the app owner can add the app to guilds
-  , fullApplicationRequiresCodeGrant Bool -- ^ When true, the app's bot will only join upon completion of the full OAuth2 code grant flow
+  , fullApplicationRequiresCodeGrant :: Bool -- ^ When true, the app's bot will only join upon completion of the full OAuth2 code grant flow
   -- , fullApplicationBot :: User -- partial user, test what it has?
-  , fullApplicationTermsOfServiceUrl :: T.Text
-  , fullApplicationPrivacyPolicyUrl :: T.Text
+  , fullApplicationTermsOfServiceUrl :: Maybe T.Text
+  , fullApplicationPrivacyPolicyUrl :: Maybe T.Text
   -- , fullApplicationOwner :: User -- ^ partial user, test what it has?
   , fullApplicationVerifyKey :: T.Text -- ^ Hex encoded key for verification in interactions and the GameSDK's GetTicket
   -- , fullApplicationTeam :: Team -- ^
+  , fullApplicationGuildID :: Maybe GuildId -- ^ Guild ID associated with the App. 
+  -- fullApplicationGuild :: PartialGuild
+  -- , fullApplicationPrimaryGameSKU
+  -- , fullApplicationSlug 
+  , fullApplicationCoverImage :: Maybe T.Text -- ^ App's default rich presence invite cover image hash
+  , fullApplicationFlags :: Maybe Integer -- ^ App's public flags
+  , fullApplicationApproximateGuildCount :: Maybe Integer -- ^ Approximate count of guilds the app has been added to
+  , fullApplicationRedirectURIs :: Maybe [T.Text] -- ^ Array of redirect URIs for the app
+  , fullApplicationInteractionEndpointURL :: Maybe T.Text -- ^ Interactions endpoint URL for the app
+  , fullApplicationRoleConnectionVerificationURL :: Maybe T.Text -- ^ Role connection verification URL for the app
+  , fullApplicationTags :: Maybe [T.Text] -- ^ List of tags describing the content and functionality of the app. Max of 5 tags.
+  -- , fullApplicationInstallParams
+  , fullApplicationCustomInstallUrl :: Maybe T.Text -- ^ Default custom authorization URL for the app, if enabled
+  } deriving (Show, Read, Eq, Ord)
+
 
 instance FromJSON FullApplication where
   parseJSON = withObject "FullApplication" $ \o ->
     FullApplication <$> o .: "id"
                     <*> o .: "name"
-                    <*> o .: "flags"
+                    <*> o .:? "icon"
+                    <*> o .: "description"
+                    <*> o .:? "rpc_origins"
+                    <*> o .: "bot_public"
+                    <*> o .: "bot_require_code_grant"
+                    -- <*> o .:? "bot"
+                    <*> o .:? "terms_of_service_url"
+                    <*> o .:? "privacy_policy_url"
+                    -- <*> o .:? "owner"
+                    <*> o .: "verify_key"
+                    -- <*> o .:? "team"
+                    <*> o .:? "guild_id"
+                    -- <*> o .:? "guild"
+                    -- <*> o .:? "primary_sku_id"
+                    -- <*> o .:? "slug"
+                    <*> o .:? "cover_image"
+                    <*> o .:? "flags"
+                    <*> o .:? "approximate_guild_count"
+                    <*> o .:? "redirect_uris"
+                    <*> o .:? "interactions_endpoint_url"
+                    <*> o .:? "role_connections_verification_url"
+                    <*> o .:? "tags"
+                    -- <*> o .:? "install_params"
+                    <*> o .:? "custom_install_url"
+
+

--- a/src/Discord/Internal/Types/ApplicationInfo.hs
+++ b/src/Discord/Internal/Types/ApplicationInfo.hs
@@ -12,8 +12,17 @@ import Discord.Internal.Types.Prelude
 data FullApplication = FullApplication
   { fullApplicationID :: ApplicationId
   , fullApplicationName :: T.Text
-  , fullApplicationFlags :: Int
-  } deriving (Show, Eq, Read)
+  , fullApplicationIcon :: Maybe T.Text -- ^ Icon hash
+  , fullApplicationDescription :: Maybe T.Text
+  , fullApplicationRPCOrigins :: [T.Text] -- ^ List of RPC origin URLs, if RPC is enabled
+  , fullApplicationBotPublic :: Bool -- ^ When false, only the app owner can add the app to guilds
+  , fullApplicationRequiresCodeGrant Bool -- ^ When true, the app's bot will only join upon completion of the full OAuth2 code grant flow
+  -- , fullApplicationBot :: User -- partial user, test what it has?
+  , fullApplicationTermsOfServiceUrl :: T.Text
+  , fullApplicationPrivacyPolicyUrl :: T.Text
+  -- , fullApplicationOwner :: User -- ^ partial user, test what it has?
+  , fullApplicationVerifyKey :: T.Text -- ^ Hex encoded key for verification in interactions and the GameSDK's GetTicket
+  -- , fullApplicationTeam :: Team -- ^ 
 
 instance FromJSON FullApplication where
   parseJSON = withObject "FullApplication" $ \o ->

--- a/src/Discord/Internal/Types/ApplicationInfo.hs
+++ b/src/Discord/Internal/Types/ApplicationInfo.hs
@@ -18,16 +18,18 @@ data FullApplication = FullApplication
   , fullApplicationRPCOrigins :: Maybe [T.Text] -- ^ List of RPC origin URLs, if RPC is enabled
   , fullApplicationBotPublic :: Bool -- ^ When false, only the app owner can add the app to guilds
   , fullApplicationRequiresCodeGrant :: Bool -- ^ When true, the app's bot will only join upon completion of the full OAuth2 code grant flow
+  , fullApplicationBotUserId :: Maybe UserId -- ^ UserId of the bot user associated with the app
   -- , fullApplicationBot :: User -- partial user, test what it has?
   , fullApplicationTermsOfServiceUrl :: Maybe T.Text
   , fullApplicationPrivacyPolicyUrl :: Maybe T.Text
+  , fullApplicationOwnerId :: Maybe UserId -- ^ UserId for the bot user associated with the app
   -- , fullApplicationOwner :: User -- ^ partial user, test what it has?
   , fullApplicationVerifyKey :: T.Text -- ^ Hex encoded key for verification in interactions and the GameSDK's GetTicket
   , fullApplicationTeam :: Maybe DiscordTeam -- ^ Included if the app belongs to a team
-  , fullApplicationGuildID :: Maybe GuildId -- ^ Guild ID associated with the App. 
-  -- fullApplicationGuild :: PartialGuild
-  -- , fullApplicationPrimaryGameSKU
-  -- , fullApplicationSlug 
+  , fullApplicationGuildId :: Maybe GuildId -- ^ Guild ID associated with the App. 
+  -- fullapplicationGuild :: PartialGuild -- ^ Don't include this because it's partial
+  , fullApplicationGameSKUId :: Maybe GameSKUId
+  , fullapplicationSlug  :: Maybe T.Text -- ^ If this app is a game sold on Discord, this field will be the URL slug that links to the store page
   , fullApplicationCoverImage :: Maybe T.Text -- ^ App's default rich presence invite cover image hash
   , fullApplicationFlags :: Maybe Integer -- ^ App's public flags
   , fullApplicationApproximateGuildCount :: Maybe Integer -- ^ Approximate count of guilds the app has been added to
@@ -35,7 +37,7 @@ data FullApplication = FullApplication
   , fullApplicationInteractionEndpointURL :: Maybe T.Text -- ^ Interactions endpoint URL for the app
   , fullApplicationRoleConnectionVerificationURL :: Maybe T.Text -- ^ Role connection verification URL for the app
   , fullApplicationTags :: Maybe [T.Text] -- ^ List of tags describing the content and functionality of the app. Max of 5 tags.
-  -- , fullApplicationInstallParams
+  , fullApplicationInstallParams :: Maybe DiscordInstallParams
   , fullApplicationCustomInstallUrl :: Maybe T.Text -- ^ Default custom authorization URL for the app, if enabled
   } deriving (Show, Read, Eq, Ord)
 
@@ -49,16 +51,16 @@ instance FromJSON FullApplication where
                     <*> o .:? "rpc_origins"
                     <*> o .: "bot_public"
                     <*> o .: "bot_require_code_grant"
-                    -- <*> o .:? "bot"
+                    <*> o .:? "bot" -- (o .:? "bot" >>= (\b -> b .: "id"))
                     <*> o .:? "terms_of_service_url"
                     <*> o .:? "privacy_policy_url"
-                    -- <*> o .:? "owner"
+                    <*> o .:? "owner" -- (o .:? "owner" >>= (\b -> b .: "id"))
                     <*> o .: "verify_key"
                     <*> o .:? "team"
                     <*> o .:? "guild_id"
                     -- <*> o .:? "guild"
-                    -- <*> o .:? "primary_sku_id"
-                    -- <*> o .:? "slug"
+                    <*> o .:? "primary_sku_id"
+                    <*> o .:? "slug"
                     <*> o .:? "cover_image"
                     <*> o .:? "flags"
                     <*> o .:? "approximate_guild_count"
@@ -66,10 +68,12 @@ instance FromJSON FullApplication where
                     <*> o .:? "interactions_endpoint_url"
                     <*> o .:? "role_connections_verification_url"
                     <*> o .:? "tags"
-                    -- <*> o .:? "install_params"
+                    <*> o .:? "install_params"
                     <*> o .:? "custom_install_url"
 
 
+zz = undefined
+zzb = undefined
 
 data DiscordTeam = DiscordTeam
   { discordTeamIcon :: Maybe T.Text
@@ -110,3 +114,15 @@ data DiscordTeamMemberState = DiscordTeamMemberStateInvited
                             | DiscordTeamMemberStateAccepted
                             | DiscordTeamMemberStateUnknown
   deriving (Show, Read, Eq, Ord)
+
+
+
+data DiscordInstallParams = DiscordInstallParams
+    { discordInstallParamsScopes :: [T.Text]
+    , discordInstallParamsPermissions :: T.Text
+    } deriving (Show, Read, Eq, Ord)
+
+instance FromJSON DiscordInstallParams where
+  parseJSON = withObject "DiscordInstallParams" $ \o ->
+    DiscordInstallParams <$> o .: "scopes"
+                         <*> o .: "permissions"

--- a/src/Discord/Internal/Types/ApplicationInfo.hs
+++ b/src/Discord/Internal/Types/ApplicationInfo.hs
@@ -5,6 +5,8 @@
 module Discord.Internal.Types.ApplicationInfo where
 
 import Data.Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KM
 import qualified Data.Text as T
 import Discord.Internal.Types.Prelude
 
@@ -51,10 +53,10 @@ instance FromJSON FullApplication where
                     <*> o .:? "rpc_origins"
                     <*> o .: "bot_public"
                     <*> o .: "bot_require_code_grant"
-                    <*> o .:? "bot" -- (o .:? "bot" >>= (\b -> b .: "id"))
+                    <*> ((\mbBot -> mbBot >>= KM.lookup (Key.fromText "id")) <$> (o .:? "bot"))
                     <*> o .:? "terms_of_service_url"
                     <*> o .:? "privacy_policy_url"
-                    <*> o .:? "owner" -- (o .:? "owner" >>= (\b -> b .: "id"))
+                    <*> ((\mbOwner -> mbOwner >>= KM.lookup (Key.fromText "id")) <$> (o .:? "owner"))
                     <*> o .: "verify_key"
                     <*> o .:? "team"
                     <*> o .:? "guild_id"
@@ -70,10 +72,6 @@ instance FromJSON FullApplication where
                     <*> o .:? "tags"
                     <*> o .:? "install_params"
                     <*> o .:? "custom_install_url"
-
-
-zz = undefined
-zzb = undefined
 
 data DiscordTeam = DiscordTeam
   { discordTeamIcon :: Maybe T.Text

--- a/src/Discord/Internal/Types/ApplicationInfo.hs
+++ b/src/Discord/Internal/Types/ApplicationInfo.hs
@@ -22,11 +22,10 @@ data FullApplication = FullApplication
   , fullApplicationPrivacyPolicyUrl :: T.Text
   -- , fullApplicationOwner :: User -- ^ partial user, test what it has?
   , fullApplicationVerifyKey :: T.Text -- ^ Hex encoded key for verification in interactions and the GameSDK's GetTicket
-  -- , fullApplicationTeam :: Team -- ^ 
+  -- , fullApplicationTeam :: Team -- ^
 
 instance FromJSON FullApplication where
   parseJSON = withObject "FullApplication" $ \o ->
     FullApplication <$> o .: "id"
                     <*> o .: "name"
                     <*> o .: "flags"
-

--- a/src/Discord/Internal/Types/ApplicationInfo.hs
+++ b/src/Discord/Internal/Types/ApplicationInfo.hs
@@ -70,3 +70,20 @@ instance FromJSON FullApplication where
                     <*> o .:? "custom_install_url"
 
 
+
+
+data DiscordTeam = DiscordTeam
+  { discordTeamIcon :: Maybe T.Text
+  , discordTeamId :: DiscordTeamId
+  , discordTeamMembers :: [DiscordTeamMember]
+  , discordTeamName :: T.Text
+  , discordTeamOwnerUserId :: UserId
+  } deriving (Show, Read, Eq, Ord)
+
+instance FromJSON DiscordTeam where
+  parseJSON = withObject "DiscordTeam" $ \o ->
+    DiscordTeam <$> o .:? "icon"
+                <*> o .:  "id"
+                <*> o .:  "members"
+                <*> o .:  "name"
+                <*> o .:  "owner_user_id"

--- a/src/Discord/Internal/Types/ApplicationInfo.hs
+++ b/src/Discord/Internal/Types/ApplicationInfo.hs
@@ -53,10 +53,10 @@ instance FromJSON FullApplication where
                     <*> o .:? "rpc_origins"
                     <*> o .: "bot_public"
                     <*> o .: "bot_require_code_grant"
-                    <*> (extractUserId <$> (o .:? "bot"))
+                    <*> (extractId <$> (o .:? "bot"))
                     <*> o .:? "terms_of_service_url"
                     <*> o .:? "privacy_policy_url"
-                    <*> (extractUserId <$> (o .:? "owner"))
+                    <*> (extractId <$> (o .:? "owner"))
                     <*> o .: "verify_key"
                     <*> o .:? "team"
                     <*> o .:? "guild_id"
@@ -73,8 +73,8 @@ instance FromJSON FullApplication where
                     <*> o .:? "install_params"
                     <*> o .:? "custom_install_url"
     where
-    extractUserId :: FromJSON a => Maybe Object -> Maybe a
-    extractUserId maybeBot = do
+    extractId :: FromJSON a => Maybe Object -> Maybe a
+    extractId maybeBot = do
       bot <- maybeBot
       v <- KM.lookup (Key.fromText "id") bot
       case fromJSON v of

--- a/src/Discord/Internal/Types/ApplicationInfo.hs
+++ b/src/Discord/Internal/Types/ApplicationInfo.hs
@@ -53,10 +53,10 @@ instance FromJSON FullApplication where
                     <*> o .:? "rpc_origins"
                     <*> o .: "bot_public"
                     <*> o .: "bot_require_code_grant"
-                    <*> ((\mbBot -> mbBot >>= KM.lookup (Key.fromText "id")) <$> (o .:? "bot"))
+                    <*> (extractUserId <$> (o .:? "bot"))
                     <*> o .:? "terms_of_service_url"
                     <*> o .:? "privacy_policy_url"
-                    <*> ((\mbOwner -> mbOwner >>= KM.lookup (Key.fromText "id")) <$> (o .:? "owner"))
+                    <*> (extractUserId <$> (o .:? "owner"))
                     <*> o .: "verify_key"
                     <*> o .:? "team"
                     <*> o .:? "guild_id"
@@ -72,6 +72,14 @@ instance FromJSON FullApplication where
                     <*> o .:? "tags"
                     <*> o .:? "install_params"
                     <*> o .:? "custom_install_url"
+    where
+    extractUserId :: FromJSON a => Maybe Object -> Maybe a
+    extractUserId maybeBot = do
+      bot <- maybeBot
+      v <- KM.lookup (Key.fromText "id") bot
+      case fromJSON v of
+          Success a -> Just a
+          _         -> Nothing
 
 data DiscordTeam = DiscordTeam
   { discordTeamIcon :: Maybe T.Text

--- a/src/Discord/Internal/Types/Prelude.hs
+++ b/src/Discord/Internal/Types/Prelude.hs
@@ -174,6 +174,9 @@ type UserId = DiscordId UserIdType
 data RoleIdType
 type RoleId = DiscordId RoleIdType
 
+data DiscordTeamIdType
+type DiscordTeamId = DiscordId DiscordTeamIdType
+
 data IntegrationIdType
 type IntegrationId = DiscordId IntegrationIdType
 

--- a/src/Discord/Internal/Types/Prelude.hs
+++ b/src/Discord/Internal/Types/Prelude.hs
@@ -25,6 +25,7 @@ module Discord.Internal.Types.Prelude
   , StickerId
   , UserId
   , DiscordTeamId
+  , GameSKUId
   , RoleId
   , IntegrationId
   , WebhookId
@@ -177,6 +178,9 @@ type RoleId = DiscordId RoleIdType
 
 data DiscordTeamIdType
 type DiscordTeamId = DiscordId DiscordTeamIdType
+
+data GameSKUIdType
+type GameSKUId = DiscordId GameSKUIdType
 
 data IntegrationIdType
 type IntegrationId = DiscordId IntegrationIdType

--- a/src/Discord/Internal/Types/Prelude.hs
+++ b/src/Discord/Internal/Types/Prelude.hs
@@ -24,6 +24,7 @@ module Discord.Internal.Types.Prelude
   , EmojiId
   , StickerId
   , UserId
+  , DiscordTeamId
   , RoleId
   , IntegrationId
   , WebhookId


### PR DESCRIPTION
Working on https://github.com/discord-haskell/discord-haskell/issues/192

Fills in majority of fields.

Currently leaving the following unimplemented: bot, owner, guild, primary_sku_id, slug, install_params

These are partial objects (can't fully parse) or specialty fields.

