### PR TITLE
Add ToJSONKey and FromJSONKey instances for Snowflake and DiscordId

### DIFF
--- a/src/Discord/Internal/Types/Prelude.hs
+++ b/src/Discord/Internal/Types/Prelude.hs
@@ -108,6 +108,12 @@ instance FromJSON Snowflake where
             (Just i) -> pure i
       )
 
+instance ToJSONKey Snowflake where
+  toJSONKey = contramapToJSONKeyFunction unSnowflake toJSONKey
+
+instance FromJSONKey Snowflake where
+  fromJSONKey = fmap Snowflake fromJSONKey
+
 instance ToHttpApiData Snowflake where
   toUrlPiece = T.pack . show
 
@@ -145,6 +151,12 @@ instance ToJSON (DiscordId a) where
 
 instance FromJSON (DiscordId a) where
   parseJSON = fmap DiscordId . parseJSON
+
+instance ToJSONKey (DiscordId a) where
+  toJSONKey = contramapToJSONKeyFunction unId toJSONKey
+
+instance FromJSONKey (DiscordId a) where
+  fromJSONKey = fmap DiscordId fromJSONKey
 
 instance ToHttpApiData (DiscordId a) where
   toUrlPiece = T.pack . show


### PR DESCRIPTION
This could be useful for people who want to have something like `Map GuildId Config` to store a separate configuration per guild.