### PR TITLE
Implemented Audit log and auto moderation rules

### DIFF
--- a/discord-haskell.cabal
+++ b/discord-haskell.cabal
@@ -143,6 +143,7 @@ library
     , Discord.Internal.Rest.ApplicationInfo
     , Discord.Internal.Rest.Interactions
     , Discord.Internal.Rest.ScheduledEvents
+    , Discord.Internal.Rest.AutoModeration
     , Discord.Internal.Types
     , Discord.Internal.Types.Prelude
     , Discord.Internal.Types.Channel
@@ -159,6 +160,7 @@ library
     , Discord.Internal.Types.Emoji
     , Discord.Internal.Types.RolePermissions
     , Discord.Internal.Types.ScheduledEvents
+    , Discord.Internal.Types.AutoModeration
   build-depends:
   -- https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/libraries/version-history
   -- below also sets the GHC version effectively. set to == 8.10.*, == 9.0.*., == 9.2.*, == 9.4.*, == 9.6.*

--- a/src/Discord/Internal/Rest/AutoModeration.hs
+++ b/src/Discord/Internal/Rest/AutoModeration.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Discord.Internal.Rest.AutoModeration 
+  ( AutoModerationRequest(..)
+  , MakeAutoModerationRule(..)
+  ) where
+
+import Data.Aeson
+import Discord.Internal.Types
+import Discord.Internal.Rest.Prelude
+import           Network.HTTP.Req ((/:), (/~))
+import qualified Network.HTTP.Req as R
+
+instance Request (AutoModerationRequest a) where
+  majorRoute  = autoModerationMajorRoute
+  jsonRequest = autoModerationJsonRequest
+
+data AutoModerationRequest a where
+  -- | Returns all audo moderation rules in a guild
+  ListAutoModerationRules  :: GuildId -> AutoModerationRequest [AutoModerationRule]
+  -- | Returns an auto moderation rule from its id
+  GetAutoModerationRule    :: GuildId -> AutoModerationRuleId -> AutoModerationRequest AutoModerationRule
+  -- | Creates an auto moderation rule in a guild
+  CreateAutoModerationRule :: GuildId -> MakeAutoModerationRule -> AutoModerationRequest ()
+  -- | Modifies (Replaces) an auto moderation rule in a guild
+  ModifyAutoModerationRule :: GuildId -> AutoModerationRuleId -> MakeAutoModerationRule -> AutoModerationRequest AutoModerationRule
+  -- | Deletes an auto moderation rule from its id
+  DeleteAutoModerationRule :: GuildId -> AutoModerationRuleId -> AutoModerationRequest ()
+
+
+data MakeAutoModerationRule = MakeAutoModerationRule
+  { makeAutoModerationRuleName            :: String
+  , makeAutoModerationRuleEventType       :: AutoModerationRuleEventType
+  , makeAutoModerationRuleTriggerType     :: AutoModerationRuleTriggerType
+  , makeAutoModerationRuleTriggerMetadata :: Maybe AutoModerationRuleTriggerMetadata
+  , makeAutoModerationRuleActions         :: [AutoModerationRuleAction]
+  , makeAutoModerationRuleEnabled         :: Bool
+  , makeAutoModerationRuleExemptRoles     :: [RoleId]
+  , makeAutoModerationRuleExemptChannels  :: [ChannelId]
+  } deriving ( Show, Read )
+
+instance FromJSON MakeAutoModerationRule where
+  parseJSON = withObject "MakeAutoModerationRule" $ \o ->
+    MakeAutoModerationRule <$> o .:  "name"
+                           <*> o .:  "event_type"
+                           <*> o .:  "trigger_type"
+                           <*> o .:? "trigger_metadata"
+                           <*> o .:  "actions"
+                           <*> o .:  "enabled"
+                           <*> o .:  "exempt_roles"
+                           <*> o .:  "exempt_channels"
+
+instance ToJSON MakeAutoModerationRule where
+  toJSON MakeAutoModerationRule{..} = objectFromMaybes
+    [ "name"              .== makeAutoModerationRuleName
+    , "event_type"        .== makeAutoModerationRuleEventType
+    , "trigger_type"      .== makeAutoModerationRuleTriggerType
+    , "trigger_metadata"  .=? makeAutoModerationRuleTriggerMetadata
+    , "actions"           .== makeAutoModerationRuleActions
+    , "enabled"           .== makeAutoModerationRuleEnabled
+    , "exempt_roles"      .== makeAutoModerationRuleExemptRoles
+    , "exempt_channels"   .== makeAutoModerationRuleExemptChannels
+    ]
+
+autoModerationMajorRoute :: AutoModerationRequest a -> String
+autoModerationMajorRoute c = case c of
+  (ListAutoModerationRules g) ->          "guild " <> show g
+  (GetAutoModerationRule g _) ->          "guild " <> show g
+  (CreateAutoModerationRule g _) ->       "guild " <> show g
+  (ModifyAutoModerationRule g _ _) ->     "guild " <> show g
+  (DeleteAutoModerationRule g _) ->       "guild " <> show g
+
+autoModerationJsonRequest :: AutoModerationRequest r -> JsonRequest
+autoModerationJsonRequest c = case c of
+  (ListAutoModerationRules guild) ->
+      Get (guilds /~ guild /: "auto-moderation" /: "rules") mempty
+  
+  (GetAutoModerationRule guild amid) ->
+      Get (guilds /~ guild /: "auto-moderation" /: "rules" /~ amid) mempty
+
+  (CreateAutoModerationRule guild autoModRule) ->
+      let body = pure (R.ReqBodyJson autoModRule)
+      in Post (guilds /~ guild /: "auto-moderation" /: "rules") body mempty
+
+  (ModifyAutoModerationRule guild amid patch) ->
+      let body = pure (R.ReqBodyJson patch)
+      in Patch (guilds /~ guild /: "auto-moderation" /: "rules" /~ amid) body mempty
+
+  (DeleteAutoModerationRule guild amid) ->
+      Delete (guilds /~ guild /: "auto-moderation" /: "rules" /~ amid) mempty
+  
+  where
+    guilds :: R.Url 'R.Https
+    guilds = baseUrl /: "guilds"

--- a/src/Discord/Internal/Rest/Guild.hs
+++ b/src/Discord/Internal/Rest/Guild.hs
@@ -113,7 +113,7 @@ data GuildRequest a where
   --   that would be removed in a prune operation. Requires the 'KICK_MEMBERS'
   --   permission.
   GetGuildPruneCount       :: GuildId -> Integer -> GuildRequest Object
-  -- | Returns an AuditLog object. includes options about time, action type,
+  -- | Returns an AuditLog object, includes options about time, action type,
   --   user that took the action and amount of entries to fetch.
   --   Requires 'VIEW_AUDIT_LOG' permission
   GetGuildAuditLog         :: GuildId -> GetAuditLogOpts -> GuildRequest AuditLog
@@ -380,28 +380,19 @@ newtype AuditLogEvent = MkAuditLogEvent Int
 instance FromJSON AuditLogEvent where
   parseJSON = fmap MkAuditLogEvent . parseJSON
 
--- | A change object, it is only partially implemented (see 'AuditLogChangeValue')
+-- | A change object, new value and old value fields are of Aesons `Value` type,
+--   because it can be pretty much any value from discord api
 data AuditLogChange = AuditLogChange
   { auditLogChangeKey      :: String
-  , auditLogChangeNewValue :: Maybe AuditLogChangeValue
-  , auditLogChangeOldValue :: Maybe AuditLogChangeValue
+  , auditLogChangeNewValue :: Maybe Value
+  , auditLogChangeOldValue :: Maybe Value
   } deriving ( Show, Read )
-
 
 instance FromJSON AuditLogChange where
   parseJSON = withObject "AuditLogChange" $ \o ->
     AuditLogChange <$> o .:  "key"
                    <*> o .:? "new_value"
                    <*> o .:? "old_value"
-
-
--- | This is a temporary solution, i really hope.
---   Discord did NOT think this through, read more at <https://discord.com/developers/docs/resources/audit-log#audit-log-change-object>
-data AuditLogChangeValue = AuditLogChangeValue String
-  deriving ( Show, Read )
-
-instance FromJSON AuditLogChangeValue where
-  parseJSON o = return $ AuditLogChangeValue (show o)
 
 -- | Optional data for the Audit Log Entry object
 data AuditLogEntryOptions = AuditLogEntryOptions

--- a/src/Discord/Internal/Types.hs
+++ b/src/Discord/Internal/Types.hs
@@ -12,6 +12,7 @@ module Discord.Internal.Types
     module Discord.Internal.Types.Components,
     module Discord.Internal.Types.Emoji,
     module Discord.Internal.Types.RolePermissions,
+    module Discord.Internal.Types.AutoModeration,
     module Data.Aeson,
     module Data.Time.Clock,
     userFacingEvent,
@@ -32,6 +33,7 @@ import Discord.Internal.Types.Guild
 import Discord.Internal.Types.Prelude
 import Discord.Internal.Types.User
 import Discord.Internal.Types.RolePermissions
+import Discord.Internal.Types.AutoModeration
 
 -- | Converts an internal event to its user facing counterpart
 userFacingEvent :: EventInternalParse -> Event

--- a/src/Discord/Internal/Types/AutoModeration.hs
+++ b/src/Discord/Internal/Types/AutoModeration.hs
@@ -1,0 +1,193 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Discord.Internal.Types.AutoModeration where
+
+import Data.Aeson
+import Discord.Internal.Types.Prelude
+
+import Data.Scientific ( toBoundedInteger )
+
+
+data AutoModerationRule = AutoModerationRule
+  { autoModerationRuleId              :: AutoModerationRuleId
+  , autoModerationRuleGuildId         :: GuildId
+  , autoModerationRuleName            :: String
+  , autoModerationRuleCreatorId       :: UserId
+  , autoModerationRuleEventType       :: AutoModerationRuleEventType
+  , autoModerationRuleTriggerType     :: AutoModerationRuleTriggerType
+  , autoModerationRuleTriggerMetadata :: AutoModerationRuleTriggerMetadata
+  , autoModerationRuleActions         :: [AutoModerationRuleAction]
+  , autoModerationRuleEnabled         :: Bool
+  , autoModerationRuleExemptRoles     :: [RoleId]
+  , autoModerationRuleExemptChannels  :: [ChannelId]
+  } deriving ( Show, Read )
+
+instance FromJSON AutoModerationRule where
+  parseJSON = withObject "AutoModerationRule" $ \o ->
+    AutoModerationRule <$> o .: "id"
+                       <*> o .: "guild_id"
+                       <*> o .: "name"
+                       <*> o .: "creator_id"
+                       <*> o .: "event_type"
+                       <*> o .: "trigger_type"
+                       <*> o .: "trigger_metadata"
+                       <*> o .: "actions"
+                       <*> o .: "enabled"
+                       <*> o .: "exempt_roles"
+                       <*> o .: "exempt_channels"
+
+instance ToJSON AutoModerationRule where
+  toJSON AutoModerationRule{..} = object
+    [ ("id", toJSON autoModerationRuleGuildId)
+    , ("guild_id", toJSON autoModerationRuleGuildId)
+    , ("name", toJSON autoModerationRuleName)
+    , ("creator_id", toJSON autoModerationRuleCreatorId)
+    , ("event_type", toJSON autoModerationRuleEventType)
+    , ("trigger_type", toJSON autoModerationRuleTriggerType)
+    , ("trigger_metadata", toJSON autoModerationRuleTriggerMetadata)
+    , ("actions", toJSON autoModerationRuleActions)
+    , ("enabled", toJSON autoModerationRuleEnabled)
+    , ("exempt_roles", toJSON autoModerationRuleExemptRoles)
+    , ("exempt_channels", toJSON autoModerationRuleExemptChannels)
+    ]
+
+-- Discord makes it pretty clear they left room for updates, so far this is the only event type
+-- See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-event-types>
+data AutoModerationRuleEventType
+  = MessageSent
+  deriving ( Show, Read )
+
+instance FromJSON AutoModerationRuleEventType where
+  parseJSON = withScientific "AutoModerationRuleEventType" $ \v -> case toBoundedInteger v :: Maybe Int of
+    Just 1 -> return MessageSent
+    _      -> fail $ "Could not parse event type: " <> show v
+
+instance ToJSON AutoModerationRuleEventType where
+  toJSON MessageSent = Number 1
+
+
+data AutoModerationRuleTriggerType
+  = Keyword
+  | Spam
+  | KeywordPreset
+  | MentionSpam
+  deriving ( Show, Read )
+
+instance FromJSON AutoModerationRuleTriggerType where
+  parseJSON = withScientific "AutoModerationTriggerType" $ \v -> case toBoundedInteger v :: Maybe Int of
+    Just 1 -> return Keyword
+    Just 3 -> return Spam
+    Just 4 -> return KeywordPreset
+    Just 5 -> return MentionSpam
+    _      -> fail $ "Could not parse trigger type: " <> show v
+
+instance ToJSON AutoModerationRuleTriggerType where
+  toJSON Keyword        = Number 1
+  toJSON Spam           = Number 3
+  toJSON KeywordPreset  = Number 4
+  toJSON MentionSpam    = Number 5
+
+data AutoModerationRuleTriggerMetadata = AutoModerationRuleTriggerMetadata
+  { autoModerationRuleTriggerMetadataKeywordFilter  :: [String]
+  , autoModerationRuleTriggerMetadataRegexPatterns  :: [String]
+  , autoModerationRuleTriggerMetadataPresets        :: Maybe [AutoModerationRuleTriggerMetadataPreset]
+  , autoModerationRuleTriggerMetadataAllowList      :: [String]
+  , autoModerationRuleTriggerMetadataMentionLimit   :: Maybe Int
+  , autoModerationRuleTriggerMetadataRaidProtection :: Maybe Bool
+  } deriving ( Show, Read )
+
+instance FromJSON AutoModerationRuleTriggerMetadata where
+  parseJSON = withObject "AutoModerationRuleTriggerMetadata" $ \o ->
+    AutoModerationRuleTriggerMetadata
+      <$> o .:  "keyword_filter"
+      <*> o .:  "regex_patterns"
+      <*> o .:? "presets"
+      <*> o .:  "allow_list"
+      <*> o .:? "mention_total_limit"
+      <*> o .:? "mention_raid_protection_enabled"
+
+instance ToJSON AutoModerationRuleTriggerMetadata where
+  toJSON AutoModerationRuleTriggerMetadata {..} = objectFromMaybes
+    [ "keyword_filter"  .== autoModerationRuleTriggerMetadataKeywordFilter
+    , "regex_patterns"  .== autoModerationRuleTriggerMetadataRegexPatterns
+    , "presets"         .=? autoModerationRuleTriggerMetadataPresets
+    , "allow_list"      .== autoModerationRuleTriggerMetadataAllowList
+    , "mention_total_limit" .=? autoModerationRuleTriggerMetadataMentionLimit
+    , "mention_raid_protection_enabled" .=? autoModerationRuleTriggerMetadataRaidProtection
+    ]
+
+data AutoModerationRuleTriggerMetadataPreset 
+  = Profanity
+  | SexualContent
+  | Slurs
+  deriving ( Show, Read )
+
+instance FromJSON AutoModerationRuleTriggerMetadataPreset where
+  parseJSON = withScientific "AutoModerationRuleTriggerMetadataPreset" $ \v -> case toBoundedInteger v :: Maybe Int of
+    Just 1 -> return Profanity
+    Just 3 -> return SexualContent
+    Just 4 -> return Slurs
+    _      -> fail $ "Could not parse preset type: " <> show v
+
+instance ToJSON AutoModerationRuleTriggerMetadataPreset where
+  toJSON Profanity      = Number 1
+  toJSON SexualContent  = Number 2
+  toJSON Slurs          = Number 3
+
+data AutoModerationRuleAction = AutoModerationRuleAction
+  { autoModerationRuleActionType      :: AutoModerationRuleActionType
+  , autoModerationRuleActionMetadata  :: Maybe AutoModerationRuleActionMetadata
+  } deriving ( Show, Read )
+
+instance FromJSON AutoModerationRuleAction where
+  parseJSON = withObject "AutoModerationRuleAction" $ \o ->
+    AutoModerationRuleAction
+      <$> o .: "type"
+      <*> o .: "metadata"
+
+instance ToJSON AutoModerationRuleAction where
+  toJSON AutoModerationRuleAction{..} = object 
+    [ ("type", toJSON autoModerationRuleActionType)
+    , ("metadata", toJSON autoModerationRuleActionMetadata)
+    ]
+
+data AutoModerationRuleActionType
+  = BlockMessage
+  | SendAlertMessage
+  | Timeout
+  deriving ( Show, Read )
+
+instance FromJSON AutoModerationRuleActionType where
+  parseJSON = withScientific "AutoModerationRuleActionType" $ \v -> case toBoundedInteger v :: Maybe Int of
+    Just 1 -> return BlockMessage
+    Just 3 -> return SendAlertMessage
+    Just 4 -> return Timeout
+    _      -> fail $ "Could not parse action type: " <> show v
+
+instance ToJSON AutoModerationRuleActionType where
+  toJSON BlockMessage     = Number 1
+  toJSON SendAlertMessage = Number 2
+  toJSON Timeout          = Number 3
+
+data AutoModerationRuleActionMetadata = AutoModerationRuleActionMetadata
+  { autoModerationRuleActionMetadataChannelId       :: Maybe ChannelId
+  , autoModerationRuleActionMetadataTimeoutDuration :: Maybe Integer
+  , autoModerationRuleActionMetadataCustomMessage   :: Maybe String
+  } deriving ( Show, Read )
+
+instance FromJSON AutoModerationRuleActionMetadata where
+  parseJSON = withObject "AutoModerationRuleActionMetadata" $ \o ->
+    AutoModerationRuleActionMetadata
+      <$> o .:? "channel_id"
+      <*> o .:? "duration_seconds"
+      <*> o .:? "custom_message"
+
+instance ToJSON AutoModerationRuleActionMetadata where
+  toJSON AutoModerationRuleActionMetadata{..} = objectFromMaybes
+    [ "channel_id"        .=? autoModerationRuleActionMetadataChannelId
+    , "duration_seconds"  .=? autoModerationRuleActionMetadataTimeoutDuration
+    , "custom_message"    .=? autoModerationRuleActionMetadataCustomMessage
+    ]

--- a/src/Discord/Internal/Types/Prelude.hs
+++ b/src/Discord/Internal/Types/Prelude.hs
@@ -33,6 +33,8 @@ module Discord.Internal.Types.Prelude
   , InteractionId
   , ScheduledEventId
   , ScheduledEventEntityId
+  , AuditLogEntryId
+  , AutoModerationRuleId
 
   , DiscordToken (..)
   , InteractionToken
@@ -197,6 +199,12 @@ type ScheduledEventId = DiscordId ScheduledEventIdType
 
 data ScheduledEventEntityIdType
 type ScheduledEventEntityId = DiscordId ScheduledEventEntityIdType
+
+data AuditLogEntryIdType
+type AuditLogEntryId = DiscordId AuditLogEntryIdType
+
+data AutoModerationRuleIdType
+type AutoModerationRuleId = DiscordId AutoModerationRuleIdType
 
 newtype DiscordToken a = DiscordToken { unToken :: T.Text }
   deriving (Ord, Eq)

--- a/src/Discord/Requests.hs
+++ b/src/Discord/Requests.hs
@@ -10,6 +10,7 @@ module Discord.Requests
   , module Discord.Internal.Rest.ApplicationCommands
   , module Discord.Internal.Rest.Interactions
   , module Discord.Internal.Rest.ScheduledEvents
+  , module Discord.Internal.Rest.AutoModeration
   ) where
 
 import Discord.Internal.Rest.ApplicationInfo
@@ -23,3 +24,4 @@ import Discord.Internal.Rest.Webhook
 import Discord.Internal.Rest.ApplicationCommands
 import Discord.Internal.Rest.Interactions
 import Discord.Internal.Rest.ScheduledEvents
+import Discord.Internal.Rest.AutoModeration


### PR DESCRIPTION
there were a few places where i am not so sure what convention to take upon, namely where to put `toAuditLogEvent` from `Discord\Internal\Rest\Guild`, and also i was forced to take liberties with the discord api doc's, as they don't list a few fields from auto moderation rules as optional, but in practice i found out that, they are often omitted by discord which caused exceptions with the parser that expected those fields.