### PR TITLE
gateway events for audit log and auto moderation

### DIFF
--- a/discord-haskell.cabal
+++ b/discord-haskell.cabal
@@ -161,6 +161,7 @@ library
     , Discord.Internal.Types.RolePermissions
     , Discord.Internal.Types.ScheduledEvents
     , Discord.Internal.Types.AutoModeration
+    , Discord.Internal.Types.AuditLog
   build-depends:
   -- https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/libraries/version-history
   -- below also sets the GHC version effectively. set to == 8.10.*, == 9.0.*., == 9.2.*, == 9.4.*, == 9.6.*

--- a/src/Discord/Internal/Rest/Guild.hs
+++ b/src/Discord/Internal/Rest/Guild.hs
@@ -16,8 +16,6 @@ module Discord.Internal.Rest.Guild
   , CreateGuildIntegrationOpts(..)
   , ModifyGuildIntegrationOpts(..)
   , ListActiveThreads (..)
-  , GetAuditLogOpts (..)
-  , toAuditLogEvent
   ) where
 
 
@@ -30,8 +28,7 @@ import Discord.Internal.Rest.Prelude
 import Discord.Internal.Types
 import Data.Default (Default(..))
 
-import Discord.Internal.Types.ApplicationCommands (ApplicationCommand)
-import Discord.Internal.Types.ScheduledEvents (ScheduledEvent)
+import Discord.Internal.Types.AuditLog ( AuditLogEvent(MkAuditLogEvent) )
 
 instance Request (GuildRequest a) where
   majorRoute = guildMajorRoute
@@ -328,127 +325,6 @@ instance FromJSON ListActiveThreads where
   parseJSON = withObject "ListActiveThreads" $ \o ->
     ListActiveThreads <$> o .: "threads"
                       <*> o .: "members"
-
--- | Audit log object, along with the entries it also contains referenced users, integrations [...] and so on
-data AuditLog = AuditLog
-  { auditLogEntries             :: [AuditLogEntry]
-  , auditLogUsers               :: [User]
-  , auditLogIntegrations        :: [Integration]
-  , auditLogWebhooks            :: [Webhook]
-  , auditlogScheduledEvents     :: [ScheduledEvent]
-  , auditLogThreads             :: [Channel]
-  , auditLogApplicationCommands :: [ApplicationCommand]
-  , auditLogAutoModerationRules :: [AutoModerationRule]
-  } deriving ( Show, Read )
-
-
-instance FromJSON AuditLog where
-  parseJSON = withObject "AuditLog" $ \o ->
-    AuditLog <$> o .: "audit_log_entries"
-             <*> o .: "users"
-             <*> o .: "integrations"
-             <*> o .: "webhooks"
-             <*> o .: "guild_scheduled_events"
-             <*> o .: "threads"
-             <*> o .: "application_commands"
-             <*> o .: "auto_moderation_rules"
-
--- | An audit log entry object, so to speak the actual event that took place
-data AuditLogEntry = AuditLogEntry
-  { auditLogEntryId         :: AuditLogEntryId
-  , auditLogEntryActionType :: AuditLogEvent
-  , auditLogEntryUserId     :: Maybe UserId
-  , auditLogEntryTargetId   :: Maybe Snowflake
-  , auditLogEntryChanges    :: Maybe [AuditLogChange]
-  , auditLogEntryOptions    :: Maybe AuditLogEntryOptions
-  , auditLogEntryReasons    :: Maybe String
-  } deriving ( Show, Read)
-
-instance FromJSON AuditLogEntry where
-  parseJSON = withObject "AuditLogEntry" $ \o ->
-    AuditLogEntry <$> o .:  "id"
-                  <*> o .:  "action_type"
-                  <*> o .:? "user_id"
-                  <*> o .:? "target_id"
-                  <*> o .:? "changes"
-                  <*> o .:? "options"
-                  <*> o .:? "reasons"
-
-newtype AuditLogEvent = MkAuditLogEvent Int
-  deriving ( Show, Read )
-
-instance FromJSON AuditLogEvent where
-  parseJSON = fmap MkAuditLogEvent . parseJSON
-
--- | A change object, new value and old value fields are of Aesons `Value` type,
---   because it can be pretty much any value from discord api
-data AuditLogChange = AuditLogChange
-  { auditLogChangeKey      :: String
-  , auditLogChangeNewValue :: Maybe Value
-  , auditLogChangeOldValue :: Maybe Value
-  } deriving ( Show, Read )
-
-instance FromJSON AuditLogChange where
-  parseJSON = withObject "AuditLogChange" $ \o ->
-    AuditLogChange <$> o .:  "key"
-                   <*> o .:? "new_value"
-                   <*> o .:? "old_value"
-
--- | Optional data for the Audit Log Entry object
-data AuditLogEntryOptions = AuditLogEntryOptions
-  { auditLogEntryOptionApplicationId                  :: Maybe ApplicationId
-  , auditLogEntryOptionAutoModerationRuleName         :: Maybe String
-  , auditLogEntryOptionAutoModerationRuleTriggerType  :: Maybe String
-  , auditLogEntryOptionChannelId                      :: Maybe ChannelId
-  , auditLogEntryOptionCount                          :: Maybe String
-  , auditLogEntryOptionDeleteMemberDays               :: Maybe String
-  , auditLogEntryOptionId                             :: Maybe Snowflake
-  , auditLogEntryOptionMembersRemoved                 :: Maybe String
-  , auditLogEntryOptionMessageId                      :: Maybe MessageId
-  , auditLogEntryOptionRoleName                       :: Maybe String
-  , auditLogEntryOptionType                           :: Maybe String
-  , auditLogEntryOptionIntegrationType                :: Maybe String
-  } deriving ( Show, Read )
-
-instance FromJSON AuditLogEntryOptions where
-  parseJSON = withObject "AuditLogEntryOption" $ \o ->
-    AuditLogEntryOptions <$> o .:? "application_id"
-                         <*> o .:? "auto_moderation_rule_name"
-                         <*> o .:? "auto_moderation_rule_trigger_type"
-                         <*> o .:? "channel_id"
-                         <*> o .:? "count"
-                         <*> o .:? "delete_member_days"
-                         <*> o .:? "id"
-                         <*> o .:? "members_removed"
-                         <*> o .:? "message_id"
-                         <*> o .:? "role_name"
-                         <*> o .:? "type"
-                         <*> o .:? "integration_type"
-
--- | Options for `GetAuditLog` request
-data GetAuditLogOpts = GetAuditLogOpts
-  { getAuditLogUserId     :: Maybe UserId
-  , getAuditLogActionType :: Maybe AuditLogEvent
-  , getAuditLogTiming     :: Maybe AuditLogTiming
-  , getAuditLogLimit      :: Maybe Int
-  } deriving ( Show, Read)
-
-instance Default GetAuditLogOpts where
-  def = GetAuditLogOpts { getAuditLogUserId     = Nothing
-                        , getAuditLogActionType = Nothing
-                        , getAuditLogTiming     = Nothing
-                        , getAuditLogLimit      = Nothing
-                        }
-
-data AuditLogTiming = BeforeLogEntry AuditLogEntryId
-                    | AfterLogEntry AuditLogEntryId
-                    | LatestLogEntries
-  deriving (Show, Read, Eq, Ord)
-
--- | See <https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events> for more information on Events
-toAuditLogEvent :: Int -> Maybe AuditLogEvent
-toAuditLogEvent i = if i `elem` (1 : 121 : [10..15] <> [20..42] <> [50..52] <> [60..62] <> [72..75] <> [80..85] <> [90..92] <> [100..102] <> [110..112] <> [140..145] <> [150, 151])
-  then Just (MkAuditLogEvent i) else Nothing
 
 
 guildMembersTimingToQuery :: GuildMembersTiming -> R.Option 'R.Https

--- a/src/Discord/Internal/Types.hs
+++ b/src/Discord/Internal/Types.hs
@@ -13,6 +13,7 @@ module Discord.Internal.Types
     module Discord.Internal.Types.Emoji,
     module Discord.Internal.Types.RolePermissions,
     module Discord.Internal.Types.AutoModeration,
+    module Discord.Internal.Types.AuditLog,
     module Data.Aeson,
     module Data.Time.Clock,
     userFacingEvent,
@@ -34,12 +35,17 @@ import Discord.Internal.Types.Prelude
 import Discord.Internal.Types.User
 import Discord.Internal.Types.RolePermissions
 import Discord.Internal.Types.AutoModeration
+import Discord.Internal.Types.AuditLog hiding ( MkAuditLogEvent )
 
 -- | Converts an internal event to its user facing counterpart
 userFacingEvent :: EventInternalParse -> Event
 userFacingEvent event = case event of
   InternalReady a b c d e f g -> Ready a b c d e f g
   InternalResumed a -> Resumed a
+  InternalAutoModerationRuleCreate a -> AutoModerationRuleCreate a
+  InternalAutoModerationRuleUpdate a -> AutoModerationRuleUpdate a
+  InternalAutoModerationRuleDelete a -> AutoModerationRuleDelete a
+  InternalAutoModerationActionExecution a -> AutoModerationActionExecution a
   InternalChannelCreate a -> ChannelCreate a
   InternalChannelUpdate a -> ChannelUpdate a
   InternalChannelDelete a -> ChannelDelete a
@@ -67,6 +73,7 @@ userFacingEvent event = case event of
   InternalMessageCreate a -> MessageCreate a
   InternalMessageUpdate a b -> MessageUpdate a b
   InternalMessageDelete a b -> MessageDelete a b
+  InternalGuildAuditLogEntryCreate a -> GuildAuditLogEntryCreate a
   InternalMessageDeleteBulk a b -> MessageDeleteBulk a b
   InternalMessageReactionAdd a -> MessageReactionAdd a
   InternalMessageReactionRemove a -> MessageReactionRemove a

--- a/src/Discord/Internal/Types/AuditLog.hs
+++ b/src/Discord/Internal/Types/AuditLog.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Discord.Internal.Types.AuditLog 
+  ( AuditLog (..)
+  , AuditLogEntry (..)
+  , AuditLogChange (..)
+  , AuditLogEntryOptions
+  , AuditLogTiming (..)
+  , GetAuditLogOpts (..)
+  , AuditLogEvent (..)
+  , toAuditLogEvent
+  ) where
+
+
+import Data.Aeson
+
+import Discord.Internal.Types.Guild (Integration)
+import Discord.Internal.Types.Prelude
+import Discord.Internal.Types.User
+import Discord.Internal.Types.ScheduledEvents
+import Discord.Internal.Types.Channel
+import Discord.Internal.Types.ApplicationCommands
+import Discord.Internal.Types.AutoModeration
+import Data.Default (Default(..))
+
+
+
+-- | Audit log object, along with the entries it also contains referenced users, integrations [...] and so on
+data AuditLog = AuditLog
+  { auditLogEntries             :: [AuditLogEntry]
+  , auditLogUsers               :: [User]
+  , auditLogIntegrations        :: [Integration]
+  , auditLogWebhooks            :: [Webhook]
+  , auditlogScheduledEvents     :: [ScheduledEvent]
+  , auditLogThreads             :: [Channel]
+  , auditLogApplicationCommands :: [ApplicationCommand]
+  , auditLogAutoModerationRules :: [AutoModerationRule]
+  } deriving ( Eq, Show, Read )
+
+
+instance FromJSON AuditLog where
+  parseJSON = withObject "AuditLog" $ \o ->
+    AuditLog <$> o .: "audit_log_entries"
+             <*> o .: "users"
+             <*> o .: "integrations"
+             <*> o .: "webhooks"
+             <*> o .: "guild_scheduled_events"
+             <*> o .: "threads"
+             <*> o .: "application_commands"
+             <*> o .: "auto_moderation_rules"
+
+-- | An audit log entry object, so to speak the actual event that took place
+data AuditLogEntry = AuditLogEntry
+  { auditLogEntryId         :: AuditLogEntryId
+  , auditLogEntryActionType :: AuditLogEvent
+  , auditLogEntryUserId     :: Maybe UserId
+  , auditLogEntryTargetId   :: Maybe Snowflake
+  , auditLogEntryChanges    :: Maybe [AuditLogChange]
+  , auditLogEntryOptions    :: Maybe AuditLogEntryOptions
+  , auditLogEntryReasons    :: Maybe String
+  } deriving ( Eq, Show, Read )
+
+instance FromJSON AuditLogEntry where
+  parseJSON = withObject "AuditLogEntry" $ \o ->
+    AuditLogEntry <$> o .:  "id"
+                  <*> o .:  "action_type"
+                  <*> o .:? "user_id"
+                  <*> o .:? "target_id"
+                  <*> o .:? "changes"
+                  <*> o .:? "options"
+                  <*> o .:? "reasons"
+
+newtype AuditLogEvent = MkAuditLogEvent Int
+  deriving ( Eq, Show, Read )
+
+instance FromJSON AuditLogEvent where
+  parseJSON = fmap MkAuditLogEvent . parseJSON
+
+-- | A change object, new value and old value fields are of Aesons `Value` type,
+--   because it can be pretty much any value from discord api
+data AuditLogChange = AuditLogChange
+  { auditLogChangeKey      :: String
+  , auditLogChangeNewValue :: Maybe Value
+  , auditLogChangeOldValue :: Maybe Value
+  } deriving ( Eq, Show, Read )
+
+instance FromJSON AuditLogChange where
+  parseJSON = withObject "AuditLogChange" $ \o ->
+    AuditLogChange <$> o .:  "key"
+                   <*> o .:? "new_value"
+                   <*> o .:? "old_value"
+
+-- | Optional data for the Audit Log Entry object
+data AuditLogEntryOptions = AuditLogEntryOptions
+  { auditLogEntryOptionApplicationId                  :: Maybe ApplicationId
+  , auditLogEntryOptionAutoModerationRuleName         :: Maybe String
+  , auditLogEntryOptionAutoModerationRuleTriggerType  :: Maybe String
+  , auditLogEntryOptionChannelId                      :: Maybe ChannelId
+  , auditLogEntryOptionCount                          :: Maybe String
+  , auditLogEntryOptionDeleteMemberDays               :: Maybe String
+  , auditLogEntryOptionId                             :: Maybe Snowflake
+  , auditLogEntryOptionMembersRemoved                 :: Maybe String
+  , auditLogEntryOptionMessageId                      :: Maybe MessageId
+  , auditLogEntryOptionRoleName                       :: Maybe String
+  , auditLogEntryOptionType                           :: Maybe String
+  , auditLogEntryOptionIntegrationType                :: Maybe String
+  } deriving ( Eq, Show, Read )
+
+instance FromJSON AuditLogEntryOptions where
+  parseJSON = withObject "AuditLogEntryOption" $ \o ->
+    AuditLogEntryOptions <$> o .:? "application_id"
+                         <*> o .:? "auto_moderation_rule_name"
+                         <*> o .:? "auto_moderation_rule_trigger_type"
+                         <*> o .:? "channel_id"
+                         <*> o .:? "count"
+                         <*> o .:? "delete_member_days"
+                         <*> o .:? "id"
+                         <*> o .:? "members_removed"
+                         <*> o .:? "message_id"
+                         <*> o .:? "role_name"
+                         <*> o .:? "type"
+                         <*> o .:? "integration_type"
+
+-- | Options for `GetAuditLog` request
+data GetAuditLogOpts = GetAuditLogOpts
+  { getAuditLogUserId     :: Maybe UserId
+  , getAuditLogActionType :: Maybe AuditLogEvent
+  , getAuditLogTiming     :: Maybe AuditLogTiming
+  , getAuditLogLimit      :: Maybe Int
+  } deriving ( Eq, Show, Read)
+
+instance Default GetAuditLogOpts where
+  def = GetAuditLogOpts { getAuditLogUserId     = Nothing
+                        , getAuditLogActionType = Nothing
+                        , getAuditLogTiming     = Nothing
+                        , getAuditLogLimit      = Nothing
+                        }
+
+data AuditLogTiming = BeforeLogEntry AuditLogEntryId
+                    | AfterLogEntry AuditLogEntryId
+                    | LatestLogEntries
+  deriving ( Show, Read, Eq, Ord)
+
+-- | See <https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events> for more information on Events
+toAuditLogEvent :: Int -> Maybe AuditLogEvent
+toAuditLogEvent i = if i `elem` (1 : 121 : [10..15] <> [20..42] <> [50..52] <> [60..62] <> [72..75] <> [80..85] <> [90..92] <> [100..102] <> [110..112] <> [140..145] <> [150, 151])
+  then Just (MkAuditLogEvent i) else Nothing

--- a/src/Discord/Internal/Types/AutoModeration.hs
+++ b/src/Discord/Internal/Types/AutoModeration.hs
@@ -7,7 +7,6 @@ module Discord.Internal.Types.AutoModeration where
 
 import Data.Aeson
 import Discord.Internal.Types.Prelude
-
 import Data.Scientific ( toBoundedInteger )
 
 
@@ -23,7 +22,7 @@ data AutoModerationRule = AutoModerationRule
   , autoModerationRuleEnabled         :: Bool
   , autoModerationRuleExemptRoles     :: [RoleId]
   , autoModerationRuleExemptChannels  :: [ChannelId]
-  } deriving ( Show, Read )
+  } deriving ( Eq, Show, Read )
 
 instance FromJSON AutoModerationRule where
   parseJSON = withObject "AutoModerationRule" $ \o ->
@@ -58,7 +57,7 @@ instance ToJSON AutoModerationRule where
 -- See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-event-types>
 data AutoModerationRuleEventType
   = MessageSent
-  deriving ( Show, Read )
+  deriving ( Eq, Show, Read )
 
 instance FromJSON AutoModerationRuleEventType where
   parseJSON = withScientific "AutoModerationRuleEventType" $ \v -> case toBoundedInteger v :: Maybe Int of
@@ -74,7 +73,7 @@ data AutoModerationRuleTriggerType
   | Spam
   | KeywordPreset
   | MentionSpam
-  deriving ( Show, Read )
+  deriving ( Eq, Show, Read )
 
 instance FromJSON AutoModerationRuleTriggerType where
   parseJSON = withScientific "AutoModerationTriggerType" $ \v -> case toBoundedInteger v :: Maybe Int of
@@ -97,7 +96,7 @@ data AutoModerationRuleTriggerMetadata = AutoModerationRuleTriggerMetadata
   , autoModerationRuleTriggerMetadataAllowList      :: [String]
   , autoModerationRuleTriggerMetadataMentionLimit   :: Maybe Int
   , autoModerationRuleTriggerMetadataRaidProtection :: Maybe Bool
-  } deriving ( Show, Read )
+  } deriving ( Eq, Show, Read )
 
 instance FromJSON AutoModerationRuleTriggerMetadata where
   parseJSON = withObject "AutoModerationRuleTriggerMetadata" $ \o ->
@@ -123,7 +122,7 @@ data AutoModerationRuleTriggerMetadataPreset
   = Profanity
   | SexualContent
   | Slurs
-  deriving ( Show, Read )
+  deriving ( Eq, Show, Read )
 
 instance FromJSON AutoModerationRuleTriggerMetadataPreset where
   parseJSON = withScientific "AutoModerationRuleTriggerMetadataPreset" $ \v -> case toBoundedInteger v :: Maybe Int of
@@ -140,7 +139,7 @@ instance ToJSON AutoModerationRuleTriggerMetadataPreset where
 data AutoModerationRuleAction = AutoModerationRuleAction
   { autoModerationRuleActionType      :: AutoModerationRuleActionType
   , autoModerationRuleActionMetadata  :: Maybe AutoModerationRuleActionMetadata
-  } deriving ( Show, Read )
+  } deriving ( Eq, Show, Read )
 
 instance FromJSON AutoModerationRuleAction where
   parseJSON = withObject "AutoModerationRuleAction" $ \o ->
@@ -158,7 +157,7 @@ data AutoModerationRuleActionType
   = BlockMessage
   | SendAlertMessage
   | Timeout
-  deriving ( Show, Read )
+  deriving ( Eq, Show, Read )
 
 instance FromJSON AutoModerationRuleActionType where
   parseJSON = withScientific "AutoModerationRuleActionType" $ \v -> case toBoundedInteger v :: Maybe Int of
@@ -176,7 +175,7 @@ data AutoModerationRuleActionMetadata = AutoModerationRuleActionMetadata
   { autoModerationRuleActionMetadataChannelId       :: Maybe ChannelId
   , autoModerationRuleActionMetadataTimeoutDuration :: Maybe Integer
   , autoModerationRuleActionMetadataCustomMessage   :: Maybe String
-  } deriving ( Show, Read )
+  } deriving ( Eq, Show, Read )
 
 instance FromJSON AutoModerationRuleActionMetadata where
   parseJSON = withObject "AutoModerationRuleActionMetadata" $ \o ->

--- a/src/Discord/Internal/Types/Events.hs
+++ b/src/Discord/Internal/Types/Events.hs
@@ -34,13 +34,13 @@ data Event =
     Ready                      Int User [GuildUnavailable] T.Text HostName (Maybe Shard) PartialApplication
   -- | Response to a @Resume@ gateway command
   | Resumed                    [T.Text]
-  -- | New auto moderation rule was created
+  -- | New auto moderation rule was created, requires the AutoModerationConfiguration intent
   | AutoModerationRuleCreate   AutoModerationRule
-  -- | Auto moderation rule was changed
+  -- | Auto moderation rule was changed, requires the AutoModerationConfiguration intent
   | AutoModerationRuleUpdate   AutoModerationRule
-  -- | Auto moderation rule was deleted
+  -- | Auto moderation rule was deleted, requires the AutoModerationConfiguration intent
   | AutoModerationRuleDelete   AutoModerationRule
-  -- | Action from an auto moderation rule was executed
+  -- | Action from an auto moderation rule was executed, requires the AutoModerationExecution intent
   | AutoModerationActionExecution  AutoModerationActionExecuteInfo
   -- | new guild channel created
   | ChannelCreate              Channel

--- a/src/Discord/Internal/Types/Gateway.hs
+++ b/src/Discord/Internal/Types/Gateway.hs
@@ -62,25 +62,29 @@ data GatewayIntent = GatewayIntent
   , gatewayIntentDirectMessageReactions :: Bool
   , gatewayIntentDirectMessageTyping :: Bool
   , gatewayIntentMessageContent :: Bool
+  , gatewayIntentAutoModerationConfiguration :: Bool
+  , gatewayIntentAutoModerationExecution :: Bool
   } deriving (Show, Read, Eq, Ord)
 
 instance Default GatewayIntent where
-  def = GatewayIntent { gatewayIntentGuilds                 = True
-                      , gatewayIntentMembers                = False -- false
-                      , gatewayIntentBans                   = True
-                      , gatewayIntentEmojis                 = True
-                      , gatewayIntentIntegrations           = True
-                      , gatewayIntentWebhooks               = True
-                      , gatewayIntentInvites                = True
-                      , gatewayIntentVoiceStates            = True
-                      , gatewayIntentPresences              = False  -- false
-                      , gatewayIntentMessageChanges         = True
-                      , gatewayIntentMessageReactions       = True
-                      , gatewayIntentMessageTyping          = True
-                      , gatewayIntentDirectMessageChanges   = True
-                      , gatewayIntentDirectMessageReactions = True
-                      , gatewayIntentDirectMessageTyping    = True
-                      , gatewayIntentMessageContent         = True
+  def = GatewayIntent { gatewayIntentGuilds                      = True
+                      , gatewayIntentMembers                     = False -- false
+                      , gatewayIntentBans                        = True
+                      , gatewayIntentEmojis                      = True
+                      , gatewayIntentIntegrations                = True
+                      , gatewayIntentWebhooks                    = True
+                      , gatewayIntentInvites                     = True
+                      , gatewayIntentVoiceStates                 = True
+                      , gatewayIntentPresences                   = False  -- false
+                      , gatewayIntentMessageChanges              = True
+                      , gatewayIntentMessageReactions            = True
+                      , gatewayIntentMessageTyping               = True
+                      , gatewayIntentDirectMessageChanges        = True
+                      , gatewayIntentDirectMessageReactions      = True
+                      , gatewayIntentDirectMessageTyping         = True
+                      , gatewayIntentMessageContent              = True
+                      , gatewayIntentAutoModerationConfiguration = True
+                      , gatewayIntentAutoModerationExecution     = True
                       }
 
 compileGatewayIntent :: GatewayIntent -> Int
@@ -102,6 +106,8 @@ compileGatewayIntent GatewayIntent{..} =
                        , (2 ^ 13, gatewayIntentDirectMessageReactions)
                        , (2 ^ 14, gatewayIntentDirectMessageTyping)
                        , (2 ^ 15, gatewayIntentMessageContent)
+                       , (2 ^ 20, gatewayIntentAutoModerationConfiguration)
+                       , (2 ^ 21, gatewayIntentAutoModerationExecution)
                        ]
        ]
 


### PR DESCRIPTION
added a new file for audit log types, moved the audit log related types from `Internal.Rest.Guild.hs` to `Internal.Types.AuditLog.hs` and wrote gateway events for audit log and auto moderation rules.