### PR TITLE
Application command attachment

### DIFF
--- a/src/Discord/Internal/Types/ApplicationCommands.hs
+++ b/src/Discord/Internal/Types/ApplicationCommands.hs
@@ -370,6 +370,18 @@ data OptionValue
         -- | The upper bound of values permitted. If choices are provided or autocomplete is on, this can be ignored
         optionValueNumberMaxVal :: Maybe Number
       }
+  | OptionValueAttachment
+      { -- | The name of the value
+        optionValueName :: T.Text,
+        -- | The localized name of the value
+        optionValueLocalizedName :: Maybe LocalizedText,
+        -- | The description of the value
+        optionValueDescription :: T.Text,
+        -- | The localized description of the value
+        optionValueLocalizedDescription :: Maybe LocalizedText,
+        -- | Whether this option is required
+        optionValueRequired :: Bool
+      }
   deriving (Show, Eq, Read)
 
 instance FromJSON OptionValue where
@@ -406,6 +418,7 @@ instance FromJSON OptionValue where
             6 -> return $ OptionValueUser name lname desc ldesc required
             8 -> return $ OptionValueRole name lname desc ldesc required
             9 -> return $ OptionValueMentionable name lname desc ldesc required
+            11 -> return $ OptionValueAttachment name lname desc ldesc required
             _ -> fail "unknown application command option value type"
       )
 
@@ -470,6 +483,7 @@ instance ToJSON OptionValue where
       t OptionValueUser {} = 6
       t OptionValueRole {} = 8
       t OptionValueMentionable {} = 9
+      t OptionValueAttachment {} = 11
       t _ = -1
 
 -- | Data type to be used when creating application commands. The specification

--- a/src/Discord/Internal/Types/Interactions.hs
+++ b/src/Discord/Internal/Types/Interactions.hs
@@ -451,6 +451,9 @@ data OptionDataValue
       }
   | OptionDataValueAttachment
       { optionDataValueName :: T.Text,
+        -- | This is a reference to the key in `ResolvedData`'s field resolvedDataAttachment.
+        --
+        -- `ResolvedData` is sent back as a response with a map of `Snowflake` to attachment objects.
         optionDataValueAttachment :: Snowflake
       }
   deriving (Show, Read, Eq, Ord)

--- a/src/Discord/Internal/Types/Interactions.hs
+++ b/src/Discord/Internal/Types/Interactions.hs
@@ -449,6 +449,10 @@ data OptionDataValue
       { optionDataValueName :: T.Text,
         optionDataValueNumber :: Either T.Text Number
       }
+  | OptionDataValueAttachment
+      { optionDataValueName :: T.Text,
+        optionDataValueAttachment :: Snowflake
+      }
   deriving (Show, Read, Eq, Ord)
 
 instance FromJSON OptionDataValue where
@@ -483,6 +487,9 @@ instance FromJSON OptionDataValue where
                 <$> v .: "value"
             9 ->
               OptionDataValueMentionable name
+                <$> v .: "value"
+            11 ->
+              OptionDataValueAttachment name
                 <$> v .: "value"
             _ -> fail $ "unexpected interaction data application command option value type: " ++ show t
       )

--- a/src/Discord/Internal/Types/Interactions.hs
+++ b/src/Discord/Internal/Types/Interactions.hs
@@ -325,7 +325,7 @@ instance FromJSON ApplicationCommandData where
       ( \v -> do
           aci <- v .: "id"
           name <- v .: "name"
-          rd <- v .:? "resolved_data"
+          rd <- v .:? "resolved"
           t <- v .: "type" :: Parser Int
           case t of
             1 ->


### PR DESCRIPTION
This adds the attachment options to ApplicationCommands as well fixes a missed key(?) for resolved data.