### PR TITLE
Allow OAuth2 bearer tokens to be used if used explicitly

### DIFF
--- a/src/Discord/Internal/Types/Prelude.hs
+++ b/src/Discord/Internal/Types/Prelude.hs
@@ -82,11 +82,27 @@ newtype Auth = Auth T.Text
   deriving (Show, Read, Eq, Ord)
 
 
--- | Get the raw token formatted for use with the websocket gateway
+-- | Format a token as required by the websocket gateway and HTTP requests, by
+-- prepending the "@Bot @" prefix. If the token already has a prefix, it is left
+-- unchanged.
+--
+-- Therefore:
+--
+-- * to use bot tokens, you can just pass them in as-is, or optionally prefix
+-- them with "@Bot @" yourself.
+-- * To use OAuth/User tokens, you must manually prefix them with "@Bearer @".
+--
+-- __Note that, if you use OAuth tokens, you have limited access to the API:__
+-- __you cannot use the websocket gateway or perform actions outside of the__
+-- __allowed scope__.
 authToken :: Auth -> T.Text
-authToken (Auth tok) = let token = T.strip tok
-                           bot = if "Bot " `T.isPrefixOf` token then "" else "Bot "
-                       in bot <> token
+authToken (Auth tok) =
+  let token = T.strip tok
+      -- Assume it's a Bot token if it doesn't have a prefix already
+      botPrefix = if "Bot " `T.isPrefixOf` token || "Bearer " `T.isPrefixOf` token
+        then ""
+        else "Bot "
+  in botPrefix <> token
 
 -- | A unique integer identifier. Can be used to calculate the creation date of an entity.
 newtype Snowflake = Snowflake { unSnowflake :: Word64 }


### PR DESCRIPTION
Fixes #213 by allowing the library user to explicitly specify the token type if they wish to do so.

I.E., `authToken` previously worked as follows:

- Prefix input with "Bot "

Now, `authToken` works as follows:

- If there is already a prefix in the input, e.g. "Bearer " or "Bot ", use it
- Otherwise, prefix input with "Bot "

I've documented the two types of tokens briefly, but a more in-depth explanation may need to be added somewhere more visible (e.g. in the README or somewhere linked from it), see https://github.com/discord-haskell/discord-haskell/issues/213#issuecomment-2551451096 for more info.