### PR TITLE
Support GHC 9.12, fixing foldl' warning in RolePermissions

### DIFF
--- a/discord-haskell.cabal
+++ b/discord-haskell.cabal
@@ -22,6 +22,7 @@ tested-with:         GHC == 8.10.7
                    , GHC == 9.6
                    , GHC == 9.8
                    , GHC == 9.10
+                   , GHC == 9.12
 extra-doc-files:     README.md
                    , changelog.md
 
@@ -166,8 +167,8 @@ library
     , Discord.Internal.Types.AuditLog
   build-depends:
   -- https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/libraries/version-history
-  -- below also sets the GHC version effectively. set to == 8.10.*, == 9.0.*., == 9.2.*, == 9.4.*, == 9.6.*, == 9.8.*, == 9.10.*,
-    base == 4.14.* || == 4.15.* || == 4.16.* || == 4.17.* || == 4.18.* || == 4.19.* || == 4.20.*,
+  -- below also sets the GHC version effectively. set to == 8.10.*, == 9.0.*., == 9.2.*, == 9.4.*, == 9.6.*, == 9.8.*, == 9.10.*, == 9.12.*,
+    base == 4.14.* || == 4.15.* || == 4.16.* || == 4.17.* || == 4.18.* || == 4.19.* || == 4.20.* || == 4.21.*,
     aeson >= 2.0 && < 2.3,
     async >=2.2 && <2.3,
     bytestring >=0.10 && <0.13,

--- a/src/Discord/Internal/Types/RolePermissions.hs
+++ b/src/Discord/Internal/Types/RolePermissions.hs
@@ -12,6 +12,7 @@ module Discord.Internal.Types.RolePermissions
   )
 where
 
+import Prelude hiding (Foldable(..))
 import Data.Bits (Bits (complement, shift, (.&.), (.|.)))
 import Discord.Internal.Types.Guild
   ( Guild,


### PR DESCRIPTION
This PR adds Tested-With and `base` bounds for GHC 9.12. 

It also fixes a redundant `foldl'` import in GHC 9.12 in RolePermissions.hs which I somehow missed before, since this had been an issue since adding GHC 9.10 support a few months back.