### PR TITLE
Parse "stage" and "voice" scheudled events correctly

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ The Discord API constantly changes. This library issues updates when we implemen
 
 ## Unreleased
 
--
+- [ShapeOfMatter](https://github.com/discord-haskell/discord-haskell/pull/231) Fix broken parsing of channel IDs in STAGE_INSTANCE and VOICE scheduled events
 
 ## 1.18.0
 

--- a/src/Discord/Internal/Types/ScheduledEvents.hs
+++ b/src/Discord/Internal/Types/ScheduledEvents.hs
@@ -167,7 +167,7 @@ instance FromJSON ScheduledEvent where
 
       case setype of
         1 -> do
-          sechid <- v .: "channelId"
+          sechid <- v .: "channel_id"
           seet   <- v .:? "scheduled_end_time"
           return $ ScheduledEventStage seid
                                        segid
@@ -184,7 +184,7 @@ instance FromJSON ScheduledEvent where
                                        seuc
                                        seim
         2 -> do
-          sechid <- v .: "channelId"
+          sechid <- v .: "channel_id"
           seet   <- v .:? "scheduled_end_time"
           return $ ScheduledEventVoice seid
                                        segid


### PR DESCRIPTION
update API parser to correctly read the Channel ID of scheduled events that have an associated channel (instead of causing an Left error).